### PR TITLE
Cleanup/refactor state manager functions

### DIFF
--- a/src/pydase/data_service/data_service.py
+++ b/src/pydase/data_service/data_service.py
@@ -222,6 +222,15 @@ class DataService(rpyc.Service, AbstractDataService):
         attr_name: str,
         value: Any,
     ) -> None:
+        warnings.warn(
+            "'update_DataService_attribute' is deprecated and will be removed in a "
+            "future version. "
+            "Service state management is handled by `pydase.data_service.state_manager`"
+            "now, instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         # If attr_name corresponds to a list entry, extract the attr_name and the index
         attr_name, index = parse_list_attr_and_index(attr_name)
         # Traverse the object according to the path parts

--- a/src/pydase/data_service/data_service.py
+++ b/src/pydase/data_service/data_service.py
@@ -13,7 +13,7 @@ from pydase.data_service.task_manager import TaskManager
 from pydase.utils.helpers import (
     convert_arguments_to_hinted_types,
     get_class_and_instance_attributes,
-    get_object_attr_from_path,
+    get_object_attr_from_path_list,
     is_property_attribute,
     parse_list_attr_and_index,
     update_value_if_changed,
@@ -234,7 +234,7 @@ class DataService(rpyc.Service, AbstractDataService):
         # If attr_name corresponds to a list entry, extract the attr_name and the index
         attr_name, index = parse_list_attr_and_index(attr_name)
         # Traverse the object according to the path parts
-        target_obj = get_object_attr_from_path(self, path_list)
+        target_obj = get_object_attr_from_path_list(self, path_list)
 
         # If the attribute is a property, change it using the setter without getting the
         # property value (would otherwise be bad for expensive getter methods)
@@ -242,7 +242,7 @@ class DataService(rpyc.Service, AbstractDataService):
             setattr(target_obj, attr_name, value)
             return
 
-        attr = get_object_attr_from_path(target_obj, [attr_name])
+        attr = get_object_attr_from_path_list(target_obj, [attr_name])
         if attr is None:
             return
 

--- a/src/pydase/data_service/state_manager.py
+++ b/src/pydase/data_service/state_manager.py
@@ -9,7 +9,7 @@ import pydase.units as u
 from pydase.data_service.data_service import process_callable_attribute
 from pydase.data_service.data_service_cache import DataServiceCache
 from pydase.utils.helpers import (
-    get_object_attr_from_path,
+    get_object_attr_from_path_list,
     is_property_attribute,
     parse_list_attr_and_index,
 )
@@ -195,7 +195,7 @@ class StateManager:
         attr_name, index = parse_list_attr_and_index(attr_name)
 
         # Traverse the object according to the path parts
-        target_obj = get_object_attr_from_path(self.service, parent_path_list)
+        target_obj = get_object_attr_from_path_list(self.service, parent_path_list)
 
         # If the attribute is a property, change it using the setter without getting
         # the property value (would otherwise be bad for expensive getter methods)

--- a/src/pydase/data_service/state_manager.py
+++ b/src/pydase/data_service/state_manager.py
@@ -113,32 +113,17 @@ class StateManager:
         serialized_class = self.cache
         for path in generate_serialized_data_paths(json_dict):
             nested_json_dict = get_nested_dict_by_path(json_dict, path)
-            value = nested_json_dict["value"]
-            value_type = nested_json_dict["type"]
-
             nested_class_dict = get_nested_dict_by_path(serialized_class, path)
-            class_value_type = nested_class_dict.get("type", None)
-            if class_value_type == value_type:
-                class_attr_is_read_only = nested_class_dict["readonly"]
-                if class_attr_is_read_only:
-                    logger.debug(
-                        f"Attribute {path!r} is read-only. Ignoring value from JSON "
-                        "file..."
-                    )
-                    continue
-                # Split the path into parts
-                parts = path.split(".")
-                attr_name = parts[-1]
 
-                # Convert dictionary into Quantity
-                if class_value_type == "Quantity":
-                    value = u.convert_to_quantity(value)
+            value, value_type = nested_json_dict["value"], nested_json_dict["type"]
+            class_attr_value_type = nested_class_dict.get("type", None)
 
-                self.service.update_DataService_attribute(parts[:-1], attr_name, value)
+            if class_attr_value_type == value_type:
+                self.set_service_attribute_value_by_path(path, value)
             else:
                 logger.info(
                     f"Attribute type of {path!r} changed from {value_type!r} to "
-                    f"{class_value_type!r}. Ignoring value from JSON file..."
+                    f"{class_attr_value_type!r}. Ignoring value from JSON file..."
                 )
 
     def _get_state_dict_from_JSON_file(self) -> dict[str, Any]:

--- a/src/pydase/data_service/state_manager.py
+++ b/src/pydase/data_service/state_manager.py
@@ -141,6 +141,20 @@ class StateManager:
         path: str,
         value: Any,
     ) -> None:
+        """
+        Sets the value of an attribute in the service managed by the `StateManager`
+        given its path as a dot-separated string.
+
+        This method updates the attribute specified by 'path' with 'value' only if the
+        attribute is not read-only and the new value differs from the current one.
+        It also handles type-specific conversions for the new value before setting it.
+
+        Args:
+            path: A dot-separated string indicating the hierarchical path to the
+                attribute.
+            value: The new value to set for the attribute.
+        """
+
         current_value_dict = get_nested_dict_by_path(self.cache, path)
 
         if current_value_dict["readonly"]:

--- a/src/pydase/server/web_server.py
+++ b/src/pydase/server/web_server.py
@@ -81,10 +81,11 @@ class WebAPI:
         @sio.event  # type: ignore
         def frontend_update(sid: str, data: UpdateDict) -> Any:
             logger.debug(f"Received frontend update: {data}")
-            path_list, attr_name = data["parent_path"].split("."), data["name"]
+            path_list = [*data["parent_path"].split("."), data["name"]]
             path_list.remove("DataService")  # always at the start, does not do anything
-            return self.service.update_DataService_attribute(
-                path_list=path_list, attr_name=attr_name, value=data["value"]
+            path = ".".join(path_list)
+            return self.state_manager.set_service_attribute_value_by_path(
+                path=path, value=data["value"]
             )
 
         self.__sio = sio

--- a/src/pydase/utils/helpers.py
+++ b/src/pydase/utils/helpers.py
@@ -31,7 +31,7 @@ def get_class_and_instance_attributes(obj: object) -> dict[str, Any]:
     return attrs
 
 
-def get_object_attr_from_path(target_obj: Any, path: list[str]) -> Any:
+def get_object_attr_from_path_list(target_obj: Any, path: list[str]) -> Any:
     """
     Traverse the object tree according to the given path.
 

--- a/tests/data_service/test_state_manager.py
+++ b/tests/data_service/test_state_manager.py
@@ -6,6 +6,7 @@ from pytest import LogCaptureFixture
 
 import pydase
 import pydase.units as u
+from pydase.components.coloured_enum import ColouredEnum
 from pydase.data_service.state_manager import StateManager
 
 
@@ -13,22 +14,56 @@ class SubService(pydase.DataService):
     name = "SubService"
 
 
+class State(ColouredEnum):
+    RUNNING = "#0000FF80"
+    COMPLETED = "hsl(120, 100%, 50%)"
+    FAILED = "hsla(0, 100%, 50%, 0.7)"
+
+
 class Service(pydase.DataService):
     def __init__(self, **kwargs: Any) -> None:
         self.subservice = SubService()
         self.some_unit: u.Quantity = 1.2 * u.units.A
         self.some_float = 1.0
+        self.list_attr = [1.0, 2.0]
+        self._property_attr = 1337.0
         self._name = "Service"
+        self._state = State.RUNNING
         super().__init__(**kwargs)
 
     @property
     def name(self) -> str:
         return self._name
 
+    @property
+    def property_attr(self) -> float:
+        return self._property_attr
+
+    @property_attr.setter
+    def property_attr(self, value: float) -> None:
+        self._property_attr = value
+
+    @property
+    def state(self) -> State:
+        return self._state
+
+    @state.setter
+    def state(self, value: State) -> None:
+        self._state = value
+
 
 CURRENT_STATE = Service().serialize()
 
 LOAD_STATE = {
+    "list_attr": {
+        "type": "list",
+        "value": [
+            {"type": "float", "value": 1.4, "readonly": False, "doc": None},
+            {"type": "float", "value": 2.0, "readonly": False, "doc": None},
+        ],
+        "readonly": False,
+        "doc": None,
+    },
     "name": {
         "type": "str",
         "value": "Another name",
@@ -41,11 +76,28 @@ LOAD_STATE = {
         "readonly": False,
         "doc": None,
     },
+    "property_attr": {
+        "type": "float",
+        "value": 1337.1,
+        "readonly": False,
+        "doc": None,
+    },
     "some_unit": {
         "type": "Quantity",
         "value": {"magnitude": 12.0, "unit": "A"},
         "readonly": False,
         "doc": None,
+    },
+    "state": {
+        "type": "ColouredEnum",
+        "value": "FAILED",
+        "readonly": True,
+        "doc": None,
+        "enum": {
+            "RUNNING": "#0000FF80",
+            "COMPLETED": "hsl(120, 100%, 50%)",
+            "FAILED": "hsla(0, 100%, 50%, 0.7)",
+        },
     },
     "subservice": {
         "type": "DataService",
@@ -94,15 +146,16 @@ def test_load_state(tmp_path: Path, caplog: LogCaptureFixture):
     manager.load_state()
 
     assert service.some_unit == u.Quantity(12, "A")  # has changed
+    assert service.list_attr[0] == 1.4  # has changed
+    assert service.list_attr[1] == 2.0  # has not changed
+    assert service.property_attr == 1337.1  # has changed
+    assert service.state == State.FAILED  # has changed
     assert service.name == "Service"  # has not changed as readonly
-    assert service.some_float == 1.0  # has not changed due to different type
     assert service.some_float == 1.0  # has not changed due to different type
     assert service.subservice.name == "SubService"  # didn't change
 
     assert "Service.some_unit changed to 12.0 A!" in caplog.text
-    assert (
-        "Attribute 'name' is read-only. Ignoring value from JSON file..." in caplog.text
-    )
+    assert "Attribute 'name' is read-only. Ignoring new value..." in caplog.text
     assert (
         "Attribute type of 'some_float' changed from 'int' to 'float'. "
         "Ignoring value from JSON file..."
@@ -144,9 +197,7 @@ def test_readonly_attribute(tmp_path: Path, caplog: LogCaptureFixture):
     service = Service()
     manager = StateManager(service=service, filename=str(file))
     manager.load_state()
-    assert (
-        "Attribute 'name' is read-only. Ignoring value from JSON file..." in caplog.text
-    )
+    assert "Attribute 'name' is read-only. Ignoring new value..." in caplog.text
 
 
 def test_changed_type(tmp_path: Path, caplog: LogCaptureFixture):

--- a/tests/data_service/test_state_manager.py
+++ b/tests/data_service/test_state_manager.py
@@ -9,8 +9,13 @@ import pydase.units as u
 from pydase.data_service.state_manager import StateManager
 
 
+class SubService(pydase.DataService):
+    name = "SubService"
+
+
 class Service(pydase.DataService):
     def __init__(self, **kwargs: Any) -> None:
+        self.subservice = SubService()
         self.some_unit: u.Quantity = 1.2 * u.units.A
         self.some_float = 1.0
         self._name = "Service"
@@ -21,43 +26,43 @@ class Service(pydase.DataService):
         return self._name
 
 
-CURRENT_STATE = {
-    "name": {
-        "type": "str",
-        "value": "Service",
-        "readonly": True,
-        "doc": None,
-    },
-    "some_float": {
-        "type": "float",
-        "value": 1.0,
-        "readonly": False,
-        "doc": None,
-    },
-    "some_unit": {
-        "type": "Quantity",
-        "value": {"magnitude": 1.2, "unit": "A"},
-        "readonly": False,
-        "doc": None,
-    },
-}
+CURRENT_STATE = Service().serialize()
 
 LOAD_STATE = {
     "name": {
         "type": "str",
-        "value": "Service",
+        "value": "Another name",
         "readonly": True,
         "doc": None,
     },
     "some_float": {
         "type": "int",
-        "value": 1,
+        "value": 10,
         "readonly": False,
         "doc": None,
     },
     "some_unit": {
         "type": "Quantity",
         "value": {"magnitude": 12.0, "unit": "A"},
+        "readonly": False,
+        "doc": None,
+    },
+    "subservice": {
+        "type": "DataService",
+        "value": {
+            "name": {
+                "type": "str",
+                "value": "SubService",
+                "readonly": False,
+                "doc": None,
+            }
+        },
+        "readonly": False,
+        "doc": None,
+    },
+    "removed_attr": {
+        "type": "str",
+        "value": "removed",
         "readonly": False,
         "doc": None,
     },
@@ -76,7 +81,7 @@ def test_save_state(tmp_path: Path):
     assert file.read_text() == json.dumps(CURRENT_STATE, indent=4)
 
 
-def test_load_state(tmp_path: Path):
+def test_load_state(tmp_path: Path, caplog: LogCaptureFixture):
     # Create a StateManager instance with a temporary file
     file = tmp_path / "test_state.json"
 
@@ -87,7 +92,26 @@ def test_load_state(tmp_path: Path):
     service = Service()
     manager = StateManager(service=service, filename=str(file))
     manager.load_state()
-    assert service.some_unit == u.Quantity(12, "A")
+
+    assert service.some_unit == u.Quantity(12, "A")  # has changed
+    assert service.name == "Service"  # has not changed as readonly
+    assert service.some_float == 1.0  # has not changed due to different type
+    assert service.some_float == 1.0  # has not changed due to different type
+    assert service.subservice.name == "SubService"  # didn't change
+
+    assert "Service.some_unit changed to 12.0 A!" in caplog.text
+    assert (
+        "Attribute 'name' is read-only. Ignoring value from JSON file..." in caplog.text
+    )
+    assert (
+        "Attribute type of 'some_float' changed from 'int' to 'float'. "
+        "Ignoring value from JSON file..."
+    ) in caplog.text
+    assert (
+        "Attribute type of 'removed_attr' changed from 'str' to None. "
+        "Ignoring value from JSON file..." in caplog.text
+    )
+    assert "Value of attribute 'subservice.name' has not changed..." in caplog.text
 
 
 def test_filename_warning(tmp_path: Path, caplog: LogCaptureFixture):


### PR DESCRIPTION
Adds methods changing the service state to the StateManager. Those methods will be used when loading the state from a json file or when an update is received from the frontend.

It also deprecates another method of `DataService` that was used before to do this.

#### TODOs
- Still needs some tests