### PR TITLE
fix: only load state properties can be updated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.3.0"
+version = "0.3.1"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/tests/data_service/test_state_manager.py
+++ b/tests/data_service/test_state_manager.py
@@ -153,7 +153,10 @@ def test_load_state(tmp_path: Path, caplog: LogCaptureFixture):
     assert service.subservice.name == "SubService"  # didn't change
 
     assert "Service.some_unit changed to 12.0 A!" in caplog.text
-    assert "Attribute 'name' is read-only. Ignoring new value..." in caplog.text
+    assert (
+        "Property 'name' has no '@load_state' decorator. "
+        "Ignoring value from JSON file..." in caplog.text
+    )
     assert (
         "Attribute type of 'some_float' changed from 'int' to 'float'. "
         "Ignoring value from JSON file..."
@@ -195,7 +198,11 @@ def test_readonly_attribute(tmp_path: Path, caplog: LogCaptureFixture):
     service = Service()
     manager = StateManager(service=service, filename=str(file))
     manager.load_state()
-    assert "Attribute 'name' is read-only. Ignoring new value..." in caplog.text
+    assert service.name == "Service"
+    assert (
+        "Property 'name' has no '@load_state' decorator. "
+        "Ignoring value from JSON file..." in caplog.text
+    )
 
 
 def test_changed_type(tmp_path: Path, caplog: LogCaptureFixture):


### PR DESCRIPTION
Only the properties decorated with @load_state could be changes through the frontend. 
This PR moves the check of the decorator into the `load_state` method of the `StateManager` and fixes the bug.