### PR TITLE
fixed serialization of class deriving from class which derives from DataService

### DIFF
--- a/src/pydase/utils/helpers.py
+++ b/src/pydase/utils/helpers.py
@@ -177,19 +177,21 @@ def parse_list_attr_and_index(attr_string: str) -> tuple[str, int | None]:
     return attr_name, index
 
 
-def get_component_class_names() -> list[str]:
+def get_component_classes() -> list[type]:
     """
-    Returns the names of the component classes in a list.
-
-    It takes the names from the pydase/components/__init__.py file, so this file should
-    always be up-to-date with the currently available components.
-
-    Returns:
-        list[str]: List of component class names
+    Returns references to the component classes in a list.
     """
     import pydase.components
 
-    return pydase.components.__all__
+    return [
+        getattr(pydase.components, cls_name) for cls_name in pydase.components.__all__
+    ]
+
+
+def get_data_service_class_reference() -> Any:
+    import pydase.data_service.data_service
+
+    return getattr(pydase.data_service.data_service, "DataService")
 
 
 def is_property_attribute(target_obj: Any, attr_name: str) -> bool:

--- a/tests/utils/test_serializer.py
+++ b/tests/utils/test_serializer.py
@@ -294,6 +294,30 @@ def test_dict_serialization() -> None:
     }
 
 
+def test_derived_data_service_serialization() -> None:
+    class BaseService(pydase.DataService):
+        class_attr = 1337
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._name = "Service"
+
+        @property
+        def name(self) -> str:
+            return self._name
+
+        @name.setter
+        def name(self, value: str) -> None:
+            self._name = value
+
+    class DerivedService(BaseService):
+        ...
+
+    base_instance = BaseService()
+    service_instance = DerivedService()
+    assert service_instance.serialize() == base_instance.serialize()
+
+
 @pytest.fixture
 def setup_dict():
     class MySubclass(pydase.DataService):


### PR DESCRIPTION
Serialization of DataService instances was handled by calculating the difference between the attributes of the instance and its base class. This PR fixed this by calculating the difference between the attributes of the instance and the DataService class.