### PR TITLE
Fix/load from file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.5.0"
+version = "0.5.1"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/src/pydase/server/server.py
+++ b/src/pydase/server/server.py
@@ -179,8 +179,8 @@ class Server:
         self._state_manager = StateManager(self._service, filename)
         if getattr(self._service, "_filename", None) is not None:
             self._service._state_manager = self._state_manager
-        self._state_manager.load_state()
         self._observer = DataServiceObserver(self._state_manager)
+        self._state_manager.load_state()
 
     def run(self) -> None:
         """

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1,8 +1,15 @@
+import json
 import signal
-
-from pytest_mock import MockerFixture
+from pathlib import Path
+from typing import Any
 
 import pydase
+import pydase.components
+import pydase.units as u
+from pydase.data_service.state_manager import load_state
+from pydase.server.server import Server
+from pytest import LogCaptureFixture
+from pytest_mock import MockerFixture
 
 
 def test_signal_handling(mocker: MockerFixture):
@@ -33,3 +40,64 @@ def test_signal_handling(mocker: MockerFixture):
     # Simulate receiving a SIGINT signal for the second time
     server.handle_exit(signal.SIGINT, None)
     mock_exit.assert_called_once_with(1)
+
+
+class Service(pydase.DataService):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.some_unit: u.Quantity = 1.2 * u.units.A
+        self.some_float = 1.0
+        self._property_attr = 1337.0
+
+    @property
+    def property_attr(self) -> float:
+        return self._property_attr
+
+    @property_attr.setter
+    @load_state
+    def property_attr(self, value: float) -> None:
+        self._property_attr = value
+
+
+CURRENT_STATE = Service().serialize()
+
+LOAD_STATE = {
+    "some_float": {
+        "type": "float",
+        "value": 10.0,
+        "readonly": False,
+        "doc": None,
+    },
+    "property_attr": {
+        "type": "float",
+        "value": 1337.1,
+        "readonly": False,
+        "doc": None,
+    },
+    "some_unit": {
+        "type": "Quantity",
+        "value": {"magnitude": 12.0, "unit": "A"},
+        "readonly": False,
+        "doc": None,
+    },
+}
+
+
+def test_load_state(tmp_path: Path, caplog: LogCaptureFixture) -> None:
+    # Create a StateManager instance with a temporary file
+    file = tmp_path / "test_state.json"
+
+    # Write a temporary JSON file to read back
+    with open(file, "w") as f:
+        json.dump(LOAD_STATE, f, indent=4)
+
+    service = Service()
+    Server(service, filename=str(file))
+
+    assert service.some_unit == u.Quantity(12, "A")
+    assert service.property_attr == 1337.1
+    assert service.some_float == 10.0
+
+    assert "'some_unit' changed to '12.0 A'" in caplog.text
+    assert "'some_float' changed to '10.0'" in caplog.text
+    assert "'property_attr' changed to '1337.1'" in caplog.text


### PR DESCRIPTION
When passing a filename to the `Server`, the cache was not filled correctly. The reason is that the observer was initialised after the state was loaded, so the observer could not tell the cache what had changed. This was reflected in the frontend by values that were not up-to-date.