### PR TITLE
Fix: dynamic list entry with property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ select = [
     "W",     # pycodestyle warnings
 ]
 ignore = [
+    "RUF006",  # asyncio-dangling-task
     "PERF203",  # try-except-in-loop
 ]
 

--- a/src/pydase/data_service/data_service_observer.py
+++ b/src/pydase/data_service/data_service_observer.py
@@ -23,6 +23,13 @@ class DataServiceObserver(PropertyObserver):
         super().__init__(state_manager.service)
 
     def on_change(self, full_access_path: str, value: Any) -> None:
+        if any(
+            full_access_path.startswith(changing_attribute)
+            and full_access_path != changing_attribute
+            for changing_attribute in self.changing_attributes
+        ):
+            return
+
         cached_value_dict = deepcopy(
             self.state_manager._data_service_cache.get_value_dict_from_cache(
                 full_access_path

--- a/src/pydase/observer_pattern/observable/observable_object.py
+++ b/src/pydase/observer_pattern/observable/observable_object.py
@@ -148,6 +148,7 @@ class _ObservableList(ObservableObject, list[Any]):
         self._notify_changed(f"[{key}]", value)
 
     def append(self, __object: Any) -> None:
+        self._notify_change_start("")
         self._initialise_new_objects(f"[{len(self)}]", __object)
         super().append(__object)
         self._notify_changed("", self)

--- a/src/pydase/observer_pattern/observer/observer.py
+++ b/src/pydase/observer_pattern/observer/observer.py
@@ -14,10 +14,10 @@ class Observer(ABC):
         self.changing_attributes: list[str] = []
 
     def _notify_changed(self, changed_attribute: str, value: Any) -> None:
+        self.on_change(full_access_path=changed_attribute, value=value)
+
         if changed_attribute in self.changing_attributes:
             self.changing_attributes.remove(changed_attribute)
-
-        self.on_change(full_access_path=changed_attribute, value=value)
 
     def _notify_change_start(self, changing_attribute: str) -> None:
         self.changing_attributes.append(changing_attribute)

--- a/tests/data_service/test_data_service_observer.py
+++ b/tests/data_service/test_data_service_observer.py
@@ -94,3 +94,31 @@ def test_protected_or_private_change_logs(caplog: pytest.LogCaptureFixture) -> N
 
     service.subclass._name = "Hello"
     assert "'subclass._name' changed to 'Hello'" not in caplog.text
+
+
+def test_dynamic_list_entry_with_property(caplog: pytest.LogCaptureFixture) -> None:
+    class PropertyClass(pydase.DataService):
+        _name = "Hello"
+
+        @property
+        def name(self) -> str:
+            """The name property."""
+            return self._name
+
+    class MyService(pydase.DataService):
+        def __init__(self) -> None:
+            super().__init__()
+            self.list_attr = []
+
+        def toggle_high_voltage(self) -> None:
+            self.list_attr = []
+            self.list_attr.append(PropertyClass())
+            self.list_attr[0]._name = "Hoooo"
+
+    service = MyService()
+    state_manager = StateManager(service)
+    DataServiceObserver(state_manager)
+    service.toggle_high_voltage()
+
+    assert "'list_attr[0].name' changed to 'Hello'" not in caplog.text
+    assert "'list_attr[0].name' changed to 'Hoooo'" in caplog.text


### PR DESCRIPTION
Dynamically adding a class instance containing a property to a list used to emit change notifications of this property although the list change wasn't emitted yet. So this code:

```python
    class PropertyClass(pydase.DataService):
        _name = "Hello"

        @property
        def name(self) -> str:
            """The name property."""
            return self._name

    class MyService(pydase.DataService):
        def __init__(self) -> None:
            super().__init__()
            self.channels = []

        def toggle_high_voltage(self) -> None:
            self.channels = []
            self.channels.append(PropertyClass())
            self.channels[0]._name = "Hoooo"
```

would emit:

```
2024-02-20 12:23:30.065 | DEBUG    | pydase.data_service.data_service_observer:on_change:43 - 'channels[0].name' changed to 'Hello'
2024-02-20 12:23:30.065 | DEBUG    | pydase.data_service.data_service_observer:on_change:43 - 'channels' changed to '[<__main__.PropertyClass object at 0x7f3c2db6f350>]'
2024-02-20 12:23:30.065 | DEBUG    | pydase.data_service.data_service_observer:on_change:43 - 'channels[0].name' changed to 'Hello'
2024-02-20 12:23:30.066 | DEBUG    | pydase.data_service.data_service_observer:on_change:43 - 'channels[0].name' changed to 'Hello'
2024-02-20 12:23:30.066 | DEBUG    | pydase.data_service.data_service_observer:on_change:43 - 'channels[0].name' changed to 'Hoooo'
```

This is caused by the serialization of the object when it is [compared to the `cached_value`](https://github.com/tiqi-group/pydase/blob/v0.6.0/src/pydase/data_service/data_service_observer.py#L33). As the object has been added to the `_ObservableList`, it could already emit such a notification even though the `'channels' changed to '[<__main__.PropertyClass object at 0x7f3c2db6f350>]'` notification hasn't yet been emitted.

This MR fixes this by
- only emitting change notifications is the containing object is not being changed itself
- telling the observer when starting to append an element to a list
- removing the path of a changed attribute only after running the `on_change` method