### PR TITLE
fixes sio callback when attribute changes to an enum which was not present before

### DIFF
--- a/src/pydase/server/web_server/sio_setup.py
+++ b/src/pydase/server/web_server/sio_setup.py
@@ -62,7 +62,7 @@ class RunMethodDict(TypedDict):
     kwargs: dict[str, Any]
 
 
-def setup_sio_server(
+def setup_sio_server(  # noqa: C901
     observer: DataServiceObserver,
     enable_cors: bool,
     loop: asyncio.AbstractEventLoop,

--- a/src/pydase/server/web_server/sio_setup.py
+++ b/src/pydase/server/web_server/sio_setup.py
@@ -103,6 +103,10 @@ def setup_sio_server(
 
             cached_value_dict["value"] = serialized_value["value"]
 
+            # Check if the serialized value contains an "enum" key, and if so, copy it
+            if "enum" in serialized_value:
+                cached_value_dict["enum"] = serialized_value["enum"]
+
             async def notify() -> None:
                 try:
                     await sio.emit(


### PR DESCRIPTION
Dynamically setting an attribute to an enumeration when it was, say, a float before will sometimes result in a broken frontend. The reason is that the serialized enum was not completely emitted - the "enum" key-value pair was missing from the dictionary.