### PR TITLE
Fix/cache update on type change

### DIFF
--- a/src/pydase/data_service/data_service_observer.py
+++ b/src/pydase/data_service/data_service_observer.py
@@ -44,8 +44,12 @@ class DataServiceObserver(PropertyObserver):
 
         self._update_cache_value(full_access_path, value, cached_value_dict)
 
-        # TODO: get the cached value again -> _update_cache_value already put the
-        # right thing into the cache
+        cached_value_dict = deepcopy(
+            self.state_manager._data_service_cache.get_value_dict_from_cache(
+                full_access_path
+            )
+        )
+
         for callback in self._notification_callbacks:
             callback(full_access_path, value, cached_value_dict)
 

--- a/src/pydase/data_service/data_service_observer.py
+++ b/src/pydase/data_service/data_service_observer.py
@@ -44,6 +44,8 @@ class DataServiceObserver(PropertyObserver):
 
         self._update_cache_value(full_access_path, value, cached_value_dict)
 
+        # TODO: get the cached value again -> _update_cache_value already put the
+        # right thing into the cache
         for callback in self._notification_callbacks:
             callback(full_access_path, value, cached_value_dict)
 

--- a/src/pydase/data_service/data_service_observer.py
+++ b/src/pydase/data_service/data_service_observer.py
@@ -42,16 +42,16 @@ class DataServiceObserver(PropertyObserver):
         ):
             logger.debug("'%s' changed to '%s'", full_access_path, value)
 
-        self._update_cache_value(full_access_path, value, cached_value_dict)
+            self._update_cache_value(full_access_path, value, cached_value_dict)
 
-        cached_value_dict = deepcopy(
-            self.state_manager._data_service_cache.get_value_dict_from_cache(
-                full_access_path
+            cached_value_dict = deepcopy(
+                self.state_manager._data_service_cache.get_value_dict_from_cache(
+                    full_access_path
+                )
             )
-        )
 
-        for callback in self._notification_callbacks:
-            callback(full_access_path, value, cached_value_dict)
+            for callback in self._notification_callbacks:
+                callback(full_access_path, value, cached_value_dict)
 
         if isinstance(value, ObservableObject):
             self._update_property_deps_dict()

--- a/src/pydase/server/web_server/sio_setup.py
+++ b/src/pydase/server/web_server/sio_setup.py
@@ -9,7 +9,6 @@ from pydase.data_service.data_service_observer import DataServiceObserver
 from pydase.data_service.state_manager import StateManager
 from pydase.utils.helpers import get_object_attr_from_path_list
 from pydase.utils.logging import SocketIOHandler
-from pydase.utils.serializer import dump
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +61,7 @@ class RunMethodDict(TypedDict):
     kwargs: dict[str, Any]
 
 
-def setup_sio_server(  # noqa: C901
+def setup_sio_server(
     observer: DataServiceObserver,
     enable_cors: bool,
     loop: asyncio.AbstractEventLoop,
@@ -97,15 +96,6 @@ def setup_sio_server(  # noqa: C901
         full_access_path: str, value: Any, cached_value_dict: dict[str, Any]
     ) -> None:
         if cached_value_dict != {}:
-            serialized_value = dump(value)
-            if cached_value_dict["type"] != "method":
-                cached_value_dict["type"] = serialized_value["type"]
-
-            cached_value_dict["value"] = serialized_value["value"]
-
-            # Check if the serialized value contains an "enum" key, and if so, copy it
-            if "enum" in serialized_value:
-                cached_value_dict["enum"] = serialized_value["enum"]
 
             async def notify() -> None:
                 try:

--- a/src/pydase/utils/serializer.py
+++ b/src/pydase/utils/serializer.py
@@ -273,9 +273,15 @@ def set_nested_value_by_path(
     value_type = serialized_value.pop("type")
     if "readonly" in current_dict and current_dict["type"] != "method":
         current_dict["type"] = value_type
-    # TODO: this does not yet remove keys that are not present in the serialized new
-    # value
+
     current_dict.update(serialized_value)
+
+    # removes keys that are not present in the serialized new value
+    keys_to_keep = set(serialized_value.keys()) | {"type", "readonly"}
+
+    for key in list(current_dict.keys()):
+        if key not in keys_to_keep:
+            current_dict.pop(key, None)
 
 
 def get_nested_dict_by_path(

--- a/src/pydase/utils/serializer.py
+++ b/src/pydase/utils/serializer.py
@@ -269,12 +269,11 @@ def set_nested_value_by_path(
 
     # setting the new value
     serialized_value = dump(value)
-    if "readonly" in current_dict:
-        if current_dict["type"] != "method":
-            current_dict["type"] = serialized_value["type"]
-        current_dict["value"] = serialized_value["value"]
-    else:
-        current_dict.update(serialized_value)
+    serialized_value.pop("readonly", None)
+    value_type = serialized_value.pop("type")
+    if "readonly" in current_dict and current_dict["type"] != "method":
+        current_dict["type"] = value_type
+    current_dict.update(serialized_value)
 
 
 def get_nested_dict_by_path(

--- a/src/pydase/utils/serializer.py
+++ b/src/pydase/utils/serializer.py
@@ -273,6 +273,8 @@ def set_nested_value_by_path(
     value_type = serialized_value.pop("type")
     if "readonly" in current_dict and current_dict["type"] != "method":
         current_dict["type"] = value_type
+    # TODO: this does not yet remove keys that are not present in the serialized new
+    # value
     current_dict.update(serialized_value)
 
 


### PR DESCRIPTION
When changing an attribute type, keys other than "value" and "type" were  not updated. This means that in case of an enumeration, the "enum" key was not present in the cache. This MR fixes this. 

The sio_callback now also gets the updated cached value and does not have to redo what the cache was doing.