### PR TITLE
feat: add "custom.css" endpoint default Response

### DIFF
--- a/src/pydase/server/web_server/web_server.py
+++ b/src/pydase/server/web_server/web_server.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import socketio  # type: ignore[import-untyped]
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -171,11 +171,12 @@ class WebServer:
             return self.web_settings
 
         # exposing custom.css file provided by user
-        if self.css is not None:
-
-            @app.get("/custom.css")
-            async def styles() -> FileResponse:
+        @app.get("/custom.css")
+        async def styles() -> Response:
+            if self.css is not None:
                 return FileResponse(str(self.css))
+
+            return Response(content="", media_type="text/css")
 
         app.mount(
             "/",


### PR DESCRIPTION
Starting an application without providing a custom css file resulted in an 404 error. This MR adds a default response now yielding an empty css file.

![image](https://github.com/tiqi-group/pydase/assets/58481522/917ebeb9-34b8-45e2-81d0-f5d946e353fa)
