### PR TITLE
adds note that coloured enum values must be unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,9 @@ my_service.status = MyStatus.FAILED
 
 ![ColouredEnum Component](docs/images/ColouredEnum_component.png)
 
+**Note** that each enumeration name and value must be unique.
+This means that you should use different colour formats when you want to use a colour multiple times.
+
 #### Extending with New Components
 
 Users can also extend the library by creating custom components. This involves defining the behavior on the Python backend and the visual representation on the frontend. For those looking to introduce new components, the [guide on adding components](https://pydase.readthedocs.io/en/latest/dev-guide/Adding_Components/) provides detailed steps on achieving this.

--- a/src/pydase/components/coloured_enum.py
+++ b/src/pydase/components/coloured_enum.py
@@ -56,4 +56,9 @@ class ColouredEnum(Enum):
     my_service = StatusExample()
     my_service.status = MyStatus.FAILED
     ```
+
+    Note
+    ----
+    Each enumeration name and value must be unique. This means that you should use
+    different colour formats when you want to use a colour multiple times.
     """


### PR DESCRIPTION
`pydase.components.ColouredEnum` derives from `enum.Enum`. This means that its keys and values need to be unique. If users want to use a colour for multiple enum keys they should use different colour formats.