### PR TITLE
Fix memory leak in ObservableObject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.8.2"
+version = "0.8.3"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/tests/observer_pattern/observable/test_observable_object.py
+++ b/tests/observer_pattern/observable/test_observable_object.py
@@ -311,3 +311,51 @@ def test_list_remove(caplog: pytest.LogCaptureFixture) -> None:
     # checks if observer key was updated correctly (was index 1)
     other_observable_instance_2.greeting = "Ciao"
     assert "'my_list[0].greeting' changed to 'Ciao'" in caplog.text
+
+
+def test_list_garbage_collection() -> None:
+    """Makes sure that the GC collects lists that are not referenced anymore."""
+
+    import gc
+    import json
+
+    list_json = """
+    [1]
+    """
+
+    class MyObservable(Observable):
+        def __init__(self) -> None:
+            super().__init__()
+            self.list_attr = json.loads(list_json)
+
+    observable = MyObservable()
+    list_mapping_length = len(observable._list_mapping)
+    observable.list_attr = json.loads(list_json)
+
+    gc.collect()
+    assert len(observable._list_mapping) <= list_mapping_length
+
+
+def test_dict_garbage_collection() -> None:
+    """Makes sure that the GC collects dicts that are not referenced anymore."""
+
+    import gc
+    import json
+
+    dict_json = """
+    {
+        "foo": "bar"
+    }
+    """
+
+    class MyObservable(Observable):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dict_attr = json.loads(dict_json)
+
+    observable = MyObservable()
+    dict_mapping_length = len(observable._dict_mapping)
+    observable.dict_attr = json.loads(dict_json)
+
+    gc.collect()
+    assert len(observable._dict_mapping) <= dict_mapping_length


### PR DESCRIPTION
Pydase currently has a significant memory leak if a `DataService` contains a dict or a list.

## Changed
- Handle adding and removing to the mappings in the derived `ObservableObject` classes
- Use weak references in dict/list mappping to avoid memory leak

## Minimal Example

```python
import json
import time

import pydase

dict_json = """
{
    "foo": "bar"
}
"""


class Service(pydase.DataService):
    def __init__(self) -> None:
        super().__init__()
        self.dict_attr = {}


service = Service()

while True:
    service.dict_attr = json.loads(dict_json)
    time.sleep(0.01)
```