### PR TITLE
Refactor: remove unused attribute key from observers dict

### DIFF
--- a/src/pydase/observer_pattern/observable/observable_object.py
+++ b/src/pydase/observer_pattern/observable/observable_object.py
@@ -32,6 +32,10 @@ class ObservableObject(ABC):
         if attribute in self._observers:
             self._observers[attribute].remove(observer)
 
+            # remove attribute key from observers dict if list of observers is empty
+            if not self._observers[attribute]:
+                del self._observers[attribute]
+
     @abstractmethod
     def _remove_observer_if_observable(self, name: str) -> None:
         """Removes the current object as an observer from an observable attribute.

--- a/tests/observer_pattern/observable/test_observable_dict.py
+++ b/tests/observer_pattern/observable/test_observable_dict.py
@@ -138,7 +138,6 @@ def test_removed_observer_on_class_dict_attr(caplog: pytest.LogCaptureFixture) -
     caplog.clear()
 
     assert nested_instance._observers == {
-        '["nested"]': [],
         "nested_attr": [instance],
     }
 
@@ -172,7 +171,6 @@ def test_removed_observer_on_instance_dict_attr(
     caplog.clear()
 
     assert nested_instance._observers == {
-        '["nested"]': [],
         "nested_attr": [instance],
     }
 
@@ -211,6 +209,6 @@ def test_pop(caplog: pytest.LogCaptureFixture) -> None:
     instance = MyObservable()
     MyObserver(instance)
     assert instance.dict_attr.pop("nested") == nested_instance
-    assert nested_instance._observers == {'["nested"]': []}
+    assert nested_instance._observers == {}
 
     assert f"'dict_attr' changed to '{instance.dict_attr}'" in caplog.text

--- a/tests/observer_pattern/observable/test_observable_object.py
+++ b/tests/observer_pattern/observable/test_observable_object.py
@@ -81,10 +81,20 @@ def test_removed_observer_on_class_list_attr(caplog: pytest.LogCaptureFixture) -
 
     instance = MyObservable()
     MyObserver(instance)
+
+    assert nested_instance._observers == {
+        "[0]": [instance.changed_list_attr],
+        "nested_attr": [instance],
+    }
+
     instance.changed_list_attr[0] = "Ciao"
 
     assert "'changed_list_attr[0]' changed to 'Ciao'" in caplog.text
     caplog.clear()
+
+    assert nested_instance._observers == {
+        "nested_attr": [instance],
+    }
 
     instance.nested_attr.name = "Hi"
 
@@ -114,6 +124,10 @@ def test_removed_observer_on_instance_list_attr(
 
     assert "'changed_list_attr[0]' changed to 'Ciao'" in caplog.text
     caplog.clear()
+
+    assert nested_instance._observers == {
+        "nested_attr": [instance],
+    }
 
     instance.nested_attr.name = "Hi"
 


### PR DESCRIPTION
The `_observers` dictionary of the `ObservableObject` keeps track of the observers of the object by mapping the access path to a list of parent objects. 
When an observer is removed, the parent object is removed from the list. If the list is empty afterwards, it is now removed from the dictionary.