### PR TITLE
Fix: allow unserializable objects on priv attrs

### DIFF
--- a/src/pydase/data_service/data_service_observer.py
+++ b/src/pydase/data_service/data_service_observer.py
@@ -37,8 +37,9 @@ class DataServiceObserver(PropertyObserver):
         )
 
         cached_value = cached_value_dict.get("value")
-        if cached_value != dump(value)["value"] and all(
-            part[0] != "_" for part in full_access_path.split(".")
+        if (
+            all(part[0] != "_" for part in full_access_path.split("."))
+            and cached_value != dump(value)["value"]
         ):
             logger.debug("'%s' changed to '%s'", full_access_path, value)
 

--- a/tests/data_service/test_data_service_observer.py
+++ b/tests/data_service/test_data_service_observer.py
@@ -1,9 +1,11 @@
 import logging
+from typing import Any
 
 import pydase
 import pytest
 from pydase.data_service.data_service_observer import DataServiceObserver
 from pydase.data_service.state_manager import StateManager
+from pydase.utils.serialization.serializer import SerializationError
 
 logger = logging.getLogger()
 
@@ -122,3 +124,25 @@ def test_dynamic_list_entry_with_property(caplog: pytest.LogCaptureFixture) -> N
 
     assert "'list_attr[0].name' changed to 'Hello'" not in caplog.text
     assert "'list_attr[0].name' changed to 'Hoooo'" in caplog.text
+
+
+def test_private_attribute_does_not_have_to_be_serializable() -> None:
+    class MyService(pydase.DataService):
+        def __init__(self) -> None:
+            super().__init__()
+            self.publ_attr: Any = 1
+            self.__priv_attr = (1,)
+
+        def change_publ_attr(self) -> None:
+            self.publ_attr = (2,)  # cannot be serialized
+
+        def change_priv_attr(self) -> None:
+            self.__priv_attr = (2,)
+
+    service_instance = MyService()
+    pydase.Server(service_instance)
+
+    with pytest.raises(SerializationError):
+        service_instance.change_publ_attr()
+
+    service_instance.change_priv_attr()


### PR DESCRIPTION
Changing private or protected attributes after the service has been exposed only worked if the object was serializable. This does not really make sense. We only need to tell dependent properties that this attribute has changed. This PR fixes this by first checking if the attribute is part of a private/protected object before serializing it to compare it to the cached value.