### PR TITLE
Breaking: changing allowed client arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ import pydase
 
 # Replace the hostname and port with the IP address and the port of the machine where 
 # the service is running, respectively
-client_proxy = pydase.Client(hostname="<ip_addr>", port=8001).proxy
+client_proxy = pydase.Client(url="ws://<ip_addr>:<service_port>").proxy
+# client_proxy = pydase.Client(url="wss://your-domain.ch").proxy  # if your service uses ssl-encryption
 
 # After the connection, interact with the service attributes as if they were local
 client_proxy.voltage = 5.0
@@ -195,7 +196,8 @@ import pydase
 
 class MyService(pydase.DataService):
     # Initialize the client without blocking the constructor
-    proxy = pydase.Client(hostname="<ip_addr>", port=8001, block_until_connected=False).proxy
+    proxy = pydase.Client(url="ws://<ip_addr>:<service_port>", block_until_connected=False).proxy
+    # proxy = pydase.Client(url="wss://your-domain.ch", block_until_connected=False).proxy  # communicating with ssl-encrypted service
 
 if __name__ == "__main__":
     service = MyService()

--- a/docs/user-guide/interaction/Python Client.md
+++ b/docs/user-guide/interaction/Python Client.md
@@ -5,9 +5,10 @@ You can connect to the service using the `pydase.Client`. Below is an example of
 ```python
 import pydase
 
-# Replace the hostname and port with the IP address and the port of the machine 
-# where the service is running, respectively
-client_proxy = pydase.Client(hostname="<ip_addr>", port=8001).proxy
+# Replace the hostname and port with the IP address and the port of the machine where 
+# the service is running, respectively
+client_proxy = pydase.Client(url="ws://<ip_addr>:<service_port>").proxy
+# client_proxy = pydase.Client(url="wss://your-domain.ch").proxy  # if your service uses ssl-encryption
 
 # Interact with the service attributes as if they were local
 client_proxy.voltage = 5.0
@@ -32,7 +33,8 @@ import pydase
 
 class MyService(pydase.DataService):
     # Initialize the client without blocking the constructor
-    proxy = pydase.Client(hostname="<ip_addr>", port=8001, block_until_connected=False).proxy
+    proxy = pydase.Client(url="ws://<ip_addr>:<service_port>", block_until_connected=False).proxy
+    # proxy = pydase.Client(url="wss://your-domain.ch", block_until_connected=False).proxy  # communicating with ssl-encrypted service
 
 if __name__ == "__main__":
     service = MyService()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.8.5"
+version = "0.9.0"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -45,7 +45,7 @@ def pydase_client() -> Generator[pydase.Client, None, Any]:
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
 
-    client = pydase.Client(hostname="localhost", port=9999)
+    client = pydase.Client(url="ws://localhost:9999")
 
     yield client
 


### PR DESCRIPTION
Users could not communicate with services that have SSL-TLS encryption enabled as the client defaulted to insecure websockets.
Programmatically constructing the URL from user input is error-prone, which is why I chose to let the users type in the URL to the remote service themselves.
The client has to be instantiated like this now:
- on local machine with port 8001:
  ```python
  pydase.Client(url="ws://localhost:8001")
  ```
- on a different host with SSL-TLS encryption enabled (e.g. through a reverse proxy)
  ```python
  pydase.Client(url="wss://other-host.ch")
  ```
  This assumes that the used port is the standard 443.