### PR TITLE
CI: fixing github-release ci job

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -70,9 +70,9 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
-        inputs: >-
+        inputs: |
           ./dist/*.tar.gz
           ./dist/*.whl
     - name: Upload artifact signatures to GitHub Release
@@ -85,27 +85,3 @@ jobs:
         gh release upload
         '${{ github.ref_name }}' dist/**
         --repo '${{ github.repository }}'
-
-  # publish-to-testpypi:
-  #   name: Publish Python 🐍 distribution 📦 to TestPyPI
-  #   needs:
-  #   - build
-  #   runs-on: ubuntu-latest
-  #
-  #   environment:
-  #     name: testpypi
-  #     url: https://test.pypi.org/p/pydase
-  #
-  #   permissions:
-  #     id-token: write  # IMPORTANT: mandatory for trusted publishing
-  #
-  #   steps:
-  #   - name: Download all the dists
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: python-package-distributions
-  #       path: dist/
-  #   - name: Publish distribution 📦 to TestPyPI
-  #     uses: pypa/gh-action-pypi-publish@release/v1
-  #     with:
-  #       repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Updates github action version of [sigstore](https://github.com/sigstore/gh-action-sigstore-python) and updates multiline input.