### PR TITLE
fix: defining task without autostart fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.10.1"
+version = "0.10.2"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/src/pydase/task/autostart.py
+++ b/src/pydase/task/autostart.py
@@ -18,6 +18,7 @@ def autostart_service_tasks(
 
     for attr in dir(service):
         if is_property_attribute(service, attr) or attr in {
+            "_observers",
             "__dict__",
         }:  # prevent eval of property attrs and recursion
             continue
@@ -40,7 +41,7 @@ def autostart_nested_service_tasks(
         autostart_service_tasks(service)
     elif isinstance(service, list):
         for entry in service:
-            autostart_service_tasks(entry)
+            autostart_nested_service_tasks(entry)
     elif isinstance(service, dict):
         for entry in service.values():
-            autostart_service_tasks(entry)
+            autostart_nested_service_tasks(entry)

--- a/src/pydase/task/autostart.py
+++ b/src/pydase/task/autostart.py
@@ -17,7 +17,9 @@ def autostart_service_tasks(
     """
 
     for attr in dir(service):
-        if is_property_attribute(service, attr):  # prevent eval of property attrs
+        if is_property_attribute(service, attr) or attr in {
+            "__dict__",
+        }:  # prevent eval of property attrs and recursion
             continue
 
         val = getattr(service, attr)

--- a/src/pydase/task/autostart.py
+++ b/src/pydase/task/autostart.py
@@ -24,12 +24,11 @@ def autostart_service_tasks(
             continue
 
         val = getattr(service, attr)
-        if (
-            isinstance(val, pydase.task.task.Task)
-            and val.autostart
-            and val.status == TaskStatus.NOT_RUNNING
-        ):
-            val.start()
+        if isinstance(val, pydase.task.task.Task):
+            if val.autostart and val.status == TaskStatus.NOT_RUNNING:
+                val.start()
+            else:
+                continue
         else:
             autostart_nested_service_tasks(val)
 

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -26,6 +26,9 @@ async def test_start_and_stop_task(caplog: LogCaptureFixture) -> None:
     service_instance = MyService()
     state_manager = StateManager(service_instance)
     DataServiceObserver(state_manager)
+
+    autostart_service_tasks(service_instance)
+
     service_instance.my_task.start()
     await asyncio.sleep(0.1)
 

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -18,9 +18,9 @@ async def test_start_and_stop_task(caplog: LogCaptureFixture) -> None:
     class MyService(pydase.DataService):
         @task()
         async def my_task(self) -> None:
+            logger.info("Triggered task.")
             while True:
-                logger.debug("Logging message")
-                await asyncio.sleep(0.01)
+                await asyncio.sleep(1)
 
     # Your test code here
     service_instance = MyService()
@@ -28,16 +28,20 @@ async def test_start_and_stop_task(caplog: LogCaptureFixture) -> None:
     DataServiceObserver(state_manager)
 
     autostart_service_tasks(service_instance)
+    await asyncio.sleep(0.1)
+    assert service_instance.my_task.status == TaskStatus.NOT_RUNNING
 
     service_instance.my_task.start()
     await asyncio.sleep(0.1)
+    assert service_instance.my_task.status == TaskStatus.RUNNING
 
     assert "'my_task.status' changed to 'TaskStatus.RUNNING'" in caplog.text
-    assert "Logging message" in caplog.text
+    assert "Triggered task." in caplog.text
     caplog.clear()
 
     service_instance.my_task.stop()
     await asyncio.sleep(0.1)
+    assert service_instance.my_task.status == TaskStatus.NOT_RUNNING
     assert "Task 'my_task' was cancelled" in caplog.text
 
 
@@ -47,6 +51,8 @@ async def test_autostart_task(caplog: LogCaptureFixture) -> None:
         @task(autostart=True)
         async def my_task(self) -> None:
             logger.info("Triggered task.")
+            while True:
+                await asyncio.sleep(1)
 
     # Your test code here
     service_instance = MyService()
@@ -56,6 +62,7 @@ async def test_autostart_task(caplog: LogCaptureFixture) -> None:
     autostart_service_tasks(service_instance)
 
     await asyncio.sleep(0.1)
+    assert service_instance.my_task.status == TaskStatus.RUNNING
 
     assert "'my_task.status' changed to 'TaskStatus.RUNNING'" in caplog.text
 
@@ -68,6 +75,8 @@ async def test_nested_list_autostart_task(
         @task(autostart=True)
         async def my_task(self) -> None:
             logger.info("Triggered task.")
+            while True:
+                await asyncio.sleep(1)
 
     class MyService(pydase.DataService):
         sub_services_list = [MySubService() for i in range(2)]
@@ -78,6 +87,8 @@ async def test_nested_list_autostart_task(
     autostart_service_tasks(service_instance)
 
     await asyncio.sleep(0.1)
+    assert service_instance.sub_services_list[0].my_task.status == TaskStatus.RUNNING
+    assert service_instance.sub_services_list[1].my_task.status == TaskStatus.RUNNING
 
     assert (
         "'sub_services_list[0].my_task.status' changed to 'TaskStatus.RUNNING'"
@@ -113,6 +124,10 @@ async def test_nested_dict_autostart_task(
 
     assert (
         service_instance.sub_services_dict["first"].my_task.status == TaskStatus.RUNNING
+    )
+    assert (
+        service_instance.sub_services_dict["second"].my_task.status
+        == TaskStatus.RUNNING
     )
 
     assert (


### PR DESCRIPTION
Fixes #158.

Tasks that had `autostart=False` or were already running were passed to `autostart_nested_services`. This caused the recursion, as tasks have a `__self__` attribute pointing to the containing service.