### PR TITLE
Fix: normalize full access path (for dict keys)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.10.2"
+version = "0.10.3"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/src/pydase/data_service/data_service_observer.py
+++ b/src/pydase/data_service/data_service_observer.py
@@ -8,7 +8,10 @@ from pydase.observer_pattern.observable.observable_object import ObservableObjec
 from pydase.observer_pattern.observer.property_observer import (
     PropertyObserver,
 )
-from pydase.utils.helpers import get_object_attr_from_path
+from pydase.utils.helpers import (
+    get_object_attr_from_path,
+    normalize_full_access_path_string,
+)
 from pydase.utils.serialization.serializer import (
     SerializationPathError,
     SerializedObject,
@@ -99,7 +102,8 @@ class DataServiceObserver(PropertyObserver):
         )
 
     def _notify_dependent_property_changes(self, changed_attr_path: str) -> None:
-        changed_props = self.property_deps_dict.get(changed_attr_path, [])
+        normalized_attr_path = normalize_full_access_path_string(changed_attr_path)
+        changed_props = self.property_deps_dict.get(normalized_attr_path, [])
         for prop in changed_props:
             # only notify about changing attribute if it is not currently being
             # "changed" e.g. when calling the getter of a property within another

--- a/src/pydase/utils/helpers.py
+++ b/src/pydase/utils/helpers.py
@@ -223,3 +223,25 @@ def current_event_loop_exists() -> bool:
     import asyncio
 
     return asyncio.get_event_loop_policy()._local._loop is not None  # type: ignore
+
+
+def normalize_full_access_path_string(s: str) -> str:
+    """Normalizes a string representing a full access path by converting double quotes
+    to single quotes.
+
+    This function is useful for ensuring consistency in strings that represent access
+    paths containing dictionary keys, by replacing all double quotes (`"`) with single
+    quotes (`'`).
+
+    Args:
+        s (str): The input string to be normalized.
+
+    Returns:
+        A new string with all double quotes replaced by single quotes.
+
+    Example:
+        >>> normalize_full_access_path_string('dictionary["first"].my_task')
+        "dictionary['first'].my_task"
+    """
+
+    return s.replace('"', "'")


### PR DESCRIPTION
Encoding a dictionary key in a full access path is usually done with single quotes, i.e. when accessing a dictionary key, the full access path will look like `"my_dict['my_key'].some_attribute"`. When changing `some_attr` through the frontend, the key will be encoded in double quotes: `'my_dict["my_key"].some_attribute'`. Thus, I have to perform some normalization.

This PR adds normalization to the `DataServiceObserver`, transforming double quotes into single quotes before comparing to the `property_deps_dict`. (This is the dictionary containing the dependencies of properties -> needed to have automatic updates for python properties objects when their dependencies change.)