### PR TITLE
fix: removes inheritance warning for descriptors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.10.3"
+version = "0.10.4"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/src/pydase/data_service/data_service.py
+++ b/src/pydase/data_service/data_service.py
@@ -10,6 +10,7 @@ from pydase.observer_pattern.observable.observable import (
 )
 from pydase.utils.helpers import (
     get_class_and_instance_attributes,
+    is_descriptor,
     is_property_attribute,
 )
 from pydase.utils.serialization.serializer import (
@@ -68,7 +69,7 @@ class DataService(AbstractDataService):
         if not issubclass(
             value_class,
             (int | float | bool | str | list | dict | Enum | u.Quantity | Observable),
-        ):
+        ) and not is_descriptor(__value):
             logger.warning(
                 "Class '%s' does not inherit from DataService. This may lead to"
                 " unexpected behaviour!",


### PR DESCRIPTION
Starting a Service containing a task was printing warnings about inheritance. This is now fixed.