### PR TITLE
Fix: client usage in jupyter notebook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.10.4"
+version = "0.10.5"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -8,7 +8,6 @@ import socketio  # type: ignore
 
 import pydase.components
 from pydase.client.proxy_loader import ProxyClassMixin, ProxyLoader
-from pydase.utils.helpers import current_event_loop_exists
 from pydase.utils.serialization.deserializer import loads
 from pydase.utils.serialization.types import SerializedDataService, SerializedObject
 
@@ -109,11 +108,7 @@ class Client:
     ):
         self._url = url
         self._sio = socketio.AsyncClient()
-        if not current_event_loop_exists():
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
-        else:
-            self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.new_event_loop()
         self.proxy = ProxyClass(sio_client=self._sio, loop=self._loop)
         """A proxy object representing the remote service, facilitating interaction as
         if it were local."""

--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -31,10 +31,7 @@ class NotifyDict(TypedDict):
 
 def asyncio_loop_thread(loop: asyncio.AbstractEventLoop) -> None:
     asyncio.set_event_loop(loop)
-    try:
-        loop.run_forever()
-    except RuntimeError:
-        logger.debug("Tried starting even loop, but it is running already")
+    loop.run_forever()
 
 
 class ProxyClass(ProxyClassMixin, pydase.components.DeviceConnection):


### PR DESCRIPTION
Trying to connect to a pydase service from a jupyter notebook fails, as I am passing async functions to the event loop of jupyter. However, this is somehow blocked. I always have to create a new thread to run the client event loop there.