### PR TITLE
Fix: logging to stdout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydase"
-version = "0.10.5"
+version = "0.10.6"
 description = "A flexible and robust Python library for creating, managing, and interacting with data services, with built-in support for web and RPC servers, and customizable features for diverse use cases."
 authors = ["Mose Mueller <mosmuell@ethz.ch>"]
 readme = "README.md"

--- a/src/pydase/utils/logging.py
+++ b/src/pydase/utils/logging.py
@@ -33,7 +33,7 @@ LOGGING_CONFIG = {
         "default": {
             "formatter": "default",
             "class": "logging.StreamHandler",
-            "stream": "ext://sys.stderr",
+            "stream": "ext://sys.stdout",
         },
     },
     "loggers": {


### PR DESCRIPTION
The logging config configured the default handler to write to stderr instead of stdout. This PR changes the behaviour.