### PR TITLE
Fix: proxy class representation

### DIFF
--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -6,8 +6,8 @@ from typing import TypedDict, cast
 
 import socketio  # type: ignore
 
-import pydase.components
-from pydase.client.proxy_loader import ProxyClassMixin, ProxyLoader
+from pydase.client.proxy_class import ProxyClass
+from pydase.client.proxy_loader import ProxyLoader
 from pydase.utils.serialization.deserializer import loads
 from pydase.utils.serialization.types import SerializedDataService, SerializedObject
 
@@ -32,47 +32,6 @@ class NotifyDict(TypedDict):
 def asyncio_loop_thread(loop: asyncio.AbstractEventLoop) -> None:
     asyncio.set_event_loop(loop)
     loop.run_forever()
-
-
-class ProxyClass(ProxyClassMixin, pydase.components.DeviceConnection):
-    """
-    A proxy class that serves as the interface for interacting with device connections
-    via a socket.io client in an asyncio environment.
-
-    Args:
-        sio_client:
-            The socket.io client instance used for asynchronous communication with the
-            pydase service server.
-        loop:
-            The event loop in which the client operations are managed and executed.
-
-    This class is used to create a proxy object that behaves like a local representation
-    of a remote pydase service, facilitating direct interaction as if it were local
-    while actually communicating over network protocols.
-    It can also be used as an attribute of a pydase service itself, e.g.
-
-    ```python
-    import pydase
-
-
-    class MyService(pydase.DataService):
-        proxy = pydase.Client(
-            hostname="...", port=8001, block_until_connected=False
-        ).proxy
-
-
-    if __name__ == "__main__":
-        service = MyService()
-        server = pydase.Server(service, web_port=8002).run()
-    ```
-    """
-
-    def __init__(
-        self, sio_client: socketio.AsyncClient, loop: asyncio.AbstractEventLoop
-    ) -> None:
-        super().__init__()
-        pydase.components.DeviceConnection.__init__(self)
-        self._initialise(sio_client=sio_client, loop=loop)
 
 
 class Client:

--- a/src/pydase/client/proxy_class.py
+++ b/src/pydase/client/proxy_class.py
@@ -1,0 +1,50 @@
+import asyncio
+import logging
+
+import socketio  # type: ignore
+
+import pydase.components
+from pydase.client.proxy_loader import ProxyClassMixin
+
+logger = logging.getLogger(__name__)
+
+
+class ProxyClass(ProxyClassMixin, pydase.components.DeviceConnection):
+    """
+    A proxy class that serves as the interface for interacting with device connections
+    via a socket.io client in an asyncio environment.
+
+    Args:
+        sio_client:
+            The socket.io client instance used for asynchronous communication with the
+            pydase service server.
+        loop:
+            The event loop in which the client operations are managed and executed.
+
+    This class is used to create a proxy object that behaves like a local representation
+    of a remote pydase service, facilitating direct interaction as if it were local
+    while actually communicating over network protocols.
+    It can also be used as an attribute of a pydase service itself, e.g.
+
+    ```python
+    import pydase
+
+
+    class MyService(pydase.DataService):
+        proxy = pydase.Client(
+            hostname="...", port=8001, block_until_connected=False
+        ).proxy
+
+
+    if __name__ == "__main__":
+        service = MyService()
+        server = pydase.Server(service, web_port=8002).run()
+    ```
+    """
+
+    def __init__(
+        self, sio_client: socketio.AsyncClient, loop: asyncio.AbstractEventLoop
+    ) -> None:
+        super().__init__()
+        pydase.components.DeviceConnection.__init__(self)
+        self._initialise(sio_client=sio_client, loop=loop)

--- a/src/pydase/client/proxy_class.py
+++ b/src/pydase/client/proxy_class.py
@@ -53,6 +53,11 @@ class ProxyClass(ProxyClassMixin, pydase.components.DeviceConnection):
         self._initialise(sio_client=sio_client, loop=loop)
 
     def serialize(self) -> SerializedObject:
+        device_connection_value = cast(
+            dict[str, SerializedObject],
+            pydase.components.DeviceConnection().serialize()["value"],
+        )
+
         readonly = False
         doc = get_attribute_doc(self)
         obj_name = self.__class__.__name__
@@ -62,7 +67,7 @@ class ProxyClass(ProxyClassMixin, pydase.components.DeviceConnection):
                 self._sio.call("service_serialization"), self._loop
             ),
         )
-        value = serialization_future.result()["value"]
+        value = {**serialization_future.result()["value"], **device_connection_value}
 
         return {
             "full_access_path": "",

--- a/src/pydase/utils/serialization/serializer.py
+++ b/src/pydase/utils/serialization/serializer.py
@@ -42,6 +42,8 @@ from pydase.utils.serialization.types import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from pydase.client.proxy_class import ProxyClass
+
 logger = logging.getLogger(__name__)
 
 
@@ -74,6 +76,7 @@ class Serializer:
         Returns:
             Dictionary representation of `obj`.
         """
+        from pydase.client.client import ProxyClass
 
         result: SerializedObject
 
@@ -82,6 +85,9 @@ class Serializer:
 
         elif isinstance(obj, datetime):
             result = cls._serialize_datetime(obj, access_path=access_path)
+
+        elif isinstance(obj, ProxyClass):
+            result = cls._serialize_proxy_class(obj, access_path=access_path)
 
         elif isinstance(obj, AbstractDataService):
             result = cls._serialize_data_service(obj, access_path=access_path)
@@ -321,6 +327,13 @@ class Serializer:
             "readonly": readonly,
             "doc": doc,
         }
+
+    @classmethod
+    def _serialize_proxy_class(
+        cls, obj: ProxyClass, access_path: str = ""
+    ) -> SerializedDataService:
+        # Get serialization value from the remote service and adapt the full_access_path
+        return add_prefix_to_full_access_path(obj.serialize(), access_path + ".")
 
 
 def dump(obj: Any) -> SerializedObject:

--- a/tests/utils/serialization/test_serializer.py
+++ b/tests/utils/serialization/test_serializer.py
@@ -1086,7 +1086,7 @@ def test_generate_serialized_data_paths(obj: Any, expected: list[str]) -> None:
                     }
                 },
             },
-            "prefix.",
+            "prefix",
             {
                 "full_access_path": "prefix.new_attr",
                 "value": {
@@ -1107,7 +1107,7 @@ def test_generate_serialized_data_paths(obj: Any, expected: list[str]) -> None:
                     }
                 ],
             },
-            "prefix.",
+            "prefix",
             {
                 "full_access_path": "prefix.new_attr",
                 "value": [
@@ -1128,7 +1128,7 @@ def test_generate_serialized_data_paths(obj: Any, expected: list[str]) -> None:
                     }
                 },
             },
-            "prefix.",
+            "prefix",
             {
                 "full_access_path": "prefix.new_attr",
                 "value": {
@@ -1144,7 +1144,7 @@ def test_generate_serialized_data_paths(obj: Any, expected: list[str]) -> None:
                 "full_access_path": "new_attr",
                 "value": {"magnitude": 10, "unit": "meter"},
             },
-            "prefix.",
+            "prefix",
             {
                 "full_access_path": "prefix.new_attr",
                 "value": {"magnitude": 10, "unit": "meter"},
@@ -1160,7 +1160,7 @@ def test_generate_serialized_data_paths(obj: Any, expected: list[str]) -> None:
                     }
                 ],
             },
-            "prefix.",
+            "prefix",
             {
                 "full_access_path": "prefix.quantity_list",
                 "value": [
@@ -1169,6 +1169,53 @@ def test_generate_serialized_data_paths(obj: Any, expected: list[str]) -> None:
                         "value": {"magnitude": 1.0, "unit": "A"},
                     }
                 ],
+            },
+        ),
+        (
+            {
+                "full_access_path": "",
+                "value": {
+                    "dict_attr": {
+                        "type": "dict",
+                        "full_access_path": "dict_attr",
+                        "value": {
+                            "foo": {
+                                "full_access_path": 'dict_attr["foo"]',
+                                "type": "dict",
+                                "value": {
+                                    "some_int": {
+                                        "full_access_path": 'dict_attr["foo"].some_int',
+                                        "type": "int",
+                                        "value": 1,
+                                    },
+                                },
+                            },
+                        },
+                    }
+                },
+            },
+            "prefix",
+            {
+                "full_access_path": "prefix",
+                "value": {
+                    "dict_attr": {
+                        "type": "dict",
+                        "full_access_path": "prefix.dict_attr",
+                        "value": {
+                            "foo": {
+                                "full_access_path": 'prefix.dict_attr["foo"]',
+                                "type": "dict",
+                                "value": {
+                                    "some_int": {
+                                        "full_access_path": 'prefix.dict_attr["foo"].some_int',
+                                        "type": "int",
+                                        "value": 1,
+                                    },
+                                },
+                            },
+                        },
+                    }
+                },
             },
         ),
     ],

--- a/tests/utils/serialization/test_serializer.py
+++ b/tests/utils/serialization/test_serializer.py
@@ -12,6 +12,7 @@ from pydase.utils.decorators import frontend
 from pydase.utils.serialization.serializer import (
     SerializationPathError,
     SerializedObject,
+    add_prefix_to_full_access_path,
     dump,
     generate_serialized_data_paths,
     get_container_item_by_key,
@@ -1070,3 +1071,109 @@ def test_get_data_paths_from_serialized_object(obj: Any, expected: list[str]) ->
 )
 def test_generate_serialized_data_paths(obj: Any, expected: list[str]) -> None:
     assert generate_serialized_data_paths(dump(obj=obj)["value"]) == expected
+
+
+@pytest.mark.parametrize(
+    "serialized_obj, prefix, expected",
+    [
+        (
+            {
+                "full_access_path": "new_attr",
+                "value": {
+                    "name": {
+                        "full_access_path": "new_attr.name",
+                        "value": "MyService",
+                    }
+                },
+            },
+            "prefix.",
+            {
+                "full_access_path": "prefix.new_attr",
+                "value": {
+                    "name": {
+                        "full_access_path": "prefix.new_attr.name",
+                        "value": "MyService",
+                    }
+                },
+            },
+        ),
+        (
+            {
+                "full_access_path": "new_attr",
+                "value": [
+                    {
+                        "full_access_path": "new_attr[0]",
+                        "value": 1.0,
+                    }
+                ],
+            },
+            "prefix.",
+            {
+                "full_access_path": "prefix.new_attr",
+                "value": [
+                    {
+                        "full_access_path": "prefix.new_attr[0]",
+                        "value": 1.0,
+                    }
+                ],
+            },
+        ),
+        (
+            {
+                "full_access_path": "new_attr",
+                "value": {
+                    "key": {
+                        "full_access_path": 'new_attr["key"]',
+                        "value": 1.0,
+                    }
+                },
+            },
+            "prefix.",
+            {
+                "full_access_path": "prefix.new_attr",
+                "value": {
+                    "key": {
+                        "full_access_path": 'prefix.new_attr["key"]',
+                        "value": 1.0,
+                    }
+                },
+            },
+        ),
+        (
+            {
+                "full_access_path": "new_attr",
+                "value": {"magnitude": 10, "unit": "meter"},
+            },
+            "prefix.",
+            {
+                "full_access_path": "prefix.new_attr",
+                "value": {"magnitude": 10, "unit": "meter"},
+            },
+        ),
+        (
+            {
+                "full_access_path": "quantity_list",
+                "value": [
+                    {
+                        "full_access_path": "quantity_list[0]",
+                        "value": {"magnitude": 1.0, "unit": "A"},
+                    }
+                ],
+            },
+            "prefix.",
+            {
+                "full_access_path": "prefix.quantity_list",
+                "value": [
+                    {
+                        "full_access_path": "prefix.quantity_list[0]",
+                        "value": {"magnitude": 1.0, "unit": "A"},
+                    }
+                ],
+            },
+        ),
+    ],
+)
+def test_add_prefix_to_full_access_path(
+    serialized_obj: SerializedObject, prefix: str, expected: SerializedObject
+) -> None:
+    assert add_prefix_to_full_access_path(serialized_obj, prefix) == expected


### PR DESCRIPTION
When a pydase service connects to another service and adds the proxy class as an attribute, the proxy was not rendered correctly: read-only properties were not read-only, tasks were not displayed correctly, and methods decorated with the `@frontend` decorator were still not shown.
The problem was that the proxy was serialized on the client side, so valuable information was lost in this process.
This PR changes that behaviour: when the proxy is serialized on the client side, it will actually request the serialized representation from the server.