### PR TITLE
Fix: removes warning message when initialising a Client

### DIFF
--- a/src/pydase/data_service/data_service.py
+++ b/src/pydase/data_service/data_service.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from collections.abc import Callable
 from enum import Enum
 from typing import Any
 
@@ -68,7 +69,18 @@ class DataService(AbstractDataService):
 
         if not issubclass(
             value_class,
-            (int | float | bool | str | list | dict | Enum | u.Quantity | Observable),
+            (
+                int
+                | float
+                | bool
+                | str
+                | list
+                | dict
+                | Enum
+                | u.Quantity
+                | Observable
+                | Callable
+            ),
         ) and not is_descriptor(__value):
             logger.warning(
                 "Class '%s' does not inherit from DataService. This may lead to"


### PR DESCRIPTION
Initialising a client was printing a warning (see [here](https://github.com/tiqi-group/pydase/issues/170#issuecomment-2388998205)). This PR fixes this.