### PR TITLE
Fix: triggering async functions 

### DIFF
--- a/src/pydase/client/proxy_loader.py
+++ b/src/pydase/client/proxy_loader.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from collections.abc import Iterable
-from copy import copy
 from typing import TYPE_CHECKING, Any, cast
 
 import socketio  # type: ignore
@@ -202,25 +201,8 @@ class ProxyClassMixin:
     def _handle_serialized_method(
         self, attr_name: str, serialized_object: SerializedObject
     ) -> None:
-        def add_prefix_to_last_path_element(s: str, prefix: str) -> str:
-            parts = s.split(".")
-            parts[-1] = f"{prefix}_{parts[-1]}"
-            return ".".join(parts)
-
         if serialized_object["type"] == "method":
-            if serialized_object["async"] is True:
-                start_method = copy(serialized_object)
-                start_method["full_access_path"] = add_prefix_to_last_path_element(
-                    start_method["full_access_path"], "start"
-                )
-                stop_method = copy(serialized_object)
-                stop_method["full_access_path"] = add_prefix_to_last_path_element(
-                    stop_method["full_access_path"], "stop"
-                )
-                self._add_method_proxy(f"start_{attr_name}", start_method)
-                self._add_method_proxy(f"stop_{attr_name}", stop_method)
-            else:
-                self._add_method_proxy(attr_name, serialized_object)
+            self._add_method_proxy(attr_name, serialized_object)
 
     def _add_method_proxy(
         self, attr_name: str, serialized_object: SerializedObject

--- a/src/pydase/server/web_server/api/v1/application.py
+++ b/src/pydase/server/web_server/api/v1/application.py
@@ -24,57 +24,75 @@ STATUS_OK = 200
 STATUS_FAILED = 400
 
 
+async def _get_value(
+    state_manager: StateManager, request: aiohttp.web.Request
+) -> aiohttp.web.Response:
+    logger.info("Handle api request: %s", request)
+
+    access_path = request.rel_url.query["access_path"]
+
+    status = STATUS_OK
+    try:
+        result = get_value(state_manager, access_path)
+    except Exception as e:
+        logger.exception(e)
+        result = dump(e)
+        status = STATUS_FAILED
+    return aiohttp.web.json_response(result, status=status)
+
+
+async def _update_value(
+    state_manager: StateManager, request: aiohttp.web.Request
+) -> aiohttp.web.Response:
+    data: UpdateDict = await request.json()
+
+    try:
+        update_value(state_manager, data)
+
+        return aiohttp.web.json_response()
+    except Exception as e:
+        logger.exception(e)
+        return aiohttp.web.json_response(dump(e), status=STATUS_FAILED)
+
+
+async def _trigger_method(
+    state_manager: StateManager, request: aiohttp.web.Request
+) -> aiohttp.web.Response:
+    data: TriggerMethodDict = await request.json()
+
+    method = get_object_attr_from_path(state_manager.service, data["access_path"])
+
+    try:
+        if inspect.iscoroutinefunction(method):
+            method_return = await trigger_async_method(
+                state_manager=state_manager, data=data
+            )
+        else:
+            method_return = trigger_method(state_manager=state_manager, data=data)
+
+        return aiohttp.web.json_response(method_return)
+
+    except Exception as e:
+        logger.exception(e)
+        return aiohttp.web.json_response(dump(e), status=STATUS_FAILED)
+
+
 def create_api_application(state_manager: StateManager) -> aiohttp.web.Application:
     api_application = aiohttp.web.Application(
         middlewares=(aiohttp_middlewares.error.error_middleware(),)
     )
 
-    async def _get_value(request: aiohttp.web.Request) -> aiohttp.web.Response:
-        logger.info("Handle api request: %s", request)
-
-        access_path = request.rel_url.query["access_path"]
-
-        status = STATUS_OK
-        try:
-            result = get_value(state_manager, access_path)
-        except Exception as e:
-            logger.exception(e)
-            result = dump(e)
-            status = STATUS_FAILED
-        return aiohttp.web.json_response(result, status=status)
-
-    async def _update_value(request: aiohttp.web.Request) -> aiohttp.web.Response:
-        data: UpdateDict = await request.json()
-
-        try:
-            update_value(state_manager, data)
-
-            return aiohttp.web.json_response()
-        except Exception as e:
-            logger.exception(e)
-            return aiohttp.web.json_response(dump(e), status=STATUS_FAILED)
-
-    async def _trigger_method(request: aiohttp.web.Request) -> aiohttp.web.Response:
-        data: TriggerMethodDict = await request.json()
-
-        method = get_object_attr_from_path(state_manager.service, data["access_path"])
-
-        try:
-            if inspect.iscoroutinefunction(method):
-                method_return = await trigger_async_method(
-                    state_manager=state_manager, data=data
-                )
-            else:
-                method_return = trigger_method(state_manager=state_manager, data=data)
-
-            return aiohttp.web.json_response(method_return)
-
-        except Exception as e:
-            logger.exception(e)
-            return aiohttp.web.json_response(dump(e), status=STATUS_FAILED)
-
-    api_application.router.add_get("/get_value", _get_value)
-    api_application.router.add_put("/update_value", _update_value)
-    api_application.router.add_put("/trigger_method", _trigger_method)
+    api_application.router.add_get(
+        "/get_value",
+        lambda request: _get_value(state_manager=state_manager, request=request),
+    )
+    api_application.router.add_put(
+        "/update_value",
+        lambda request: _update_value(state_manager=state_manager, request=request),
+    )
+    api_application.router.add_put(
+        "/trigger_method",
+        lambda request: _trigger_method(state_manager=state_manager, request=request),
+    )
 
     return api_application

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -41,6 +41,9 @@ def pydase_client() -> Generator[pydase.Client, None, Any]:
         def my_method(self, input_str: str) -> str:
             return input_str
 
+        async def my_async_method(self, input_str: str) -> str:
+            return input_str
+
     server = pydase.Server(MyService(), web_port=9999)
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
@@ -77,6 +80,14 @@ def test_method_execution(pydase_client: pydase.Client) -> None:
 
     with pytest.raises(TypeError):
         pydase_client.proxy.my_method(kwarg="hello")
+
+
+def test_async_method_execution(pydase_client: pydase.Client) -> None:
+    assert pydase_client.proxy.my_async_method("My return string") == "My return string"
+    assert (
+        pydase_client.proxy.my_async_method(input_str="My return string")
+        == "My return string"
+    )
 
 
 def test_nested_service(pydase_client: pydase.Client) -> None:


### PR DESCRIPTION
Asynchronous functions could not be triggered by either client (browser, python, or restapi). This PR adds support for this. The async function will be awaited in the running asyncio event loop.