### PR TITLE
Fix: client context manager

### DIFF
--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import threading
 import urllib.parse
+from types import TracebackType
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import socketio  # type: ignore
@@ -109,10 +110,14 @@ class Client:
         self.connect(block_until_connected=block_until_connected)
 
     def __enter__(self) -> Self:
-        self.connect(block_until_connected=True)
         return self
 
-    def __del__(self) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self.disconnect()
 
     def connect(self, block_until_connected: bool = True) -> None:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -149,3 +149,15 @@ def test_tab_completion(pydase_client: pydase.Client) -> None:
             "sub_service",
         ]
     )
+
+
+def test_context_manager(pydase_client: pydase.Client) -> None:
+    client = pydase.Client(url="ws://localhost:9999")
+
+    assert client.proxy.connected
+
+    with client:
+        client.proxy.my_property = 1337.01
+        assert client.proxy.my_property == 1337.01
+
+    assert not client.proxy.connected


### PR DESCRIPTION
Using the client in a context manager fails as `__exit__` is not implemented. This PR fixes this.