### PR TITLE
feat: log trace when exception occurs within trigger_method

### DIFF
--- a/src/pydase/server/web_server/sio_setup.py
+++ b/src/pydase/server/web_server/sio_setup.py
@@ -185,7 +185,7 @@ def setup_sio_events(sio: socketio.AsyncServer, state_manager: StateManager) -> 
                 )
             return endpoints.trigger_method(state_manager=state_manager, data=data)
         except Exception as e:
-            logger.error(e)
+            logger.exception(e)
             return dump(e)
 
 


### PR DESCRIPTION
When an exception occurs within a function call, this exception is now printed to stderr. Formerly, you would only get the exception message as a `logger.error`.