### PR TITLE
Feat: add more task config options

### DIFF
--- a/src/pydase/task/decorator.py
+++ b/src/pydase/task/decorator.py
@@ -97,7 +97,7 @@ class PerInstanceTaskDescriptor(Generic[R]):
 def task(  # noqa: PLR0913
     *,
     autostart: bool = False,
-    restart_on_failure: bool = False,
+    restart_on_failure: bool = True,
     restart_sec: float = 1.0,
     start_limit_interval_sec: float | None = None,
     start_limit_burst: int = 3,

--- a/src/pydase/task/decorator.py
+++ b/src/pydase/task/decorator.py
@@ -35,7 +35,6 @@ class PerInstanceTaskDescriptor(Generic[R]):
         restart_sec: float,
         start_limit_interval_sec: float | None,
         start_limit_burst: int,
-        timeout_start_sec: float,
         exit_on_failure: bool,
     ) -> None:
         self.__func = func
@@ -45,7 +44,6 @@ class PerInstanceTaskDescriptor(Generic[R]):
         self.__restart_sec = restart_sec
         self.__start_limit_interval_sec = start_limit_interval_sec
         self.__start_limit_burst = start_limit_burst
-        self.__timeout_start_sec = timeout_start_sec
         self.__exit_on_failure = exit_on_failure
 
     def __set_name__(self, owner: type[DataService], name: str) -> None:
@@ -86,7 +84,6 @@ class PerInstanceTaskDescriptor(Generic[R]):
                     restart_sec=self.__restart_sec,
                     start_limit_interval_sec=self.__start_limit_interval_sec,
                     start_limit_burst=self.__start_limit_burst,
-                    timeout_start_sec=self.__timeout_start_sec,
                     exit_on_failure=self.__exit_on_failure,
                 ),
             )
@@ -101,7 +98,6 @@ def task(  # noqa: PLR0913
     restart_sec: float = 1.0,
     start_limit_interval_sec: float | None = None,
     start_limit_burst: int = 3,
-    timeout_start_sec: float = 0.0,
     exit_on_failure: bool = False,
 ) -> Callable[
     [
@@ -145,8 +141,6 @@ def task(  # noqa: PLR0913
             Configures unit start rate limiting. Tasks which are started more than
             `start_limit_burst` times within an `start_limit_interval_sec` time span are
             not permitted to start any more. Defaults to 3.
-        timeout_start_sec:
-            Configures the time to wait for start-up. Defaults to 0.0.
         exit_on_failure:
             If True, exit the service if the task fails and restart_on_failure is False
             or burst limits are exceeded.
@@ -194,7 +188,6 @@ def task(  # noqa: PLR0913
             restart_sec=restart_sec,
             start_limit_interval_sec=start_limit_interval_sec,
             start_limit_burst=start_limit_burst,
-            timeout_start_sec=timeout_start_sec,
             exit_on_failure=exit_on_failure,
         )
 

--- a/src/pydase/task/decorator.py
+++ b/src/pydase/task/decorator.py
@@ -36,6 +36,7 @@ class PerInstanceTaskDescriptor(Generic[R]):
         start_limit_interval_sec: float | None = None,
         start_limit_burst: int = 3,
         timeout_start_sec: float = 0.0,
+        exit_on_failure: bool = False,
     ) -> None:
         self.__func = func
         self.__autostart = autostart
@@ -45,6 +46,7 @@ class PerInstanceTaskDescriptor(Generic[R]):
         self.__start_limit_interval_sec = start_limit_interval_sec
         self.__start_limit_burst = start_limit_burst
         self.__timeout_start_sec = timeout_start_sec
+        self.__exit_on_failure = exit_on_failure
 
     def __set_name__(self, owner: type[DataService], name: str) -> None:
         """Stores the name of the task within the owning class. This method is called
@@ -85,6 +87,7 @@ class PerInstanceTaskDescriptor(Generic[R]):
                     start_limit_interval_sec=self.__start_limit_interval_sec,
                     start_limit_burst=self.__start_limit_burst,
                     timeout_start_sec=self.__timeout_start_sec,
+                    exit_on_failure=self.__exit_on_failure,
                 ),
             )
 
@@ -99,6 +102,7 @@ def task(  # noqa: PLR0913
     start_limit_interval_sec: float | None = None,
     start_limit_burst: int = 3,
     timeout_start_sec: float = 0.0,
+    exit_on_failure: bool = False,
 ) -> Callable[
     [
         Callable[[Any], Coroutine[None, None, R]]
@@ -143,6 +147,9 @@ def task(  # noqa: PLR0913
             not permitted to start any more. Defaults to 3.
         timeout_start_sec:
             Configures the time to wait for start-up. Defaults to 0.0.
+        exit_on_failure:
+            If True, exit the service if the task fails and restart_on_failure is False
+            or burst limits are exceeded.
     Returns:
         A decorator that wraps an asynchronous function in a
         [`PerInstanceTaskDescriptor`][pydase.task.decorator.PerInstanceTaskDescriptor]
@@ -188,6 +195,7 @@ def task(  # noqa: PLR0913
             start_limit_interval_sec=start_limit_interval_sec,
             start_limit_burst=start_limit_burst,
             timeout_start_sec=timeout_start_sec,
+            exit_on_failure=exit_on_failure,
         )
 
     return decorator

--- a/src/pydase/task/decorator.py
+++ b/src/pydase/task/decorator.py
@@ -26,15 +26,25 @@ class PerInstanceTaskDescriptor(Generic[R]):
     the service class.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         func: Callable[[Any], Coroutine[None, None, R]]
         | Callable[[], Coroutine[None, None, R]],
         autostart: bool = False,
+        restart_on_failure: bool = False,
+        restart_sec: float = 1.0,
+        start_limit_interval_sec: float | None = None,
+        start_limit_burst: int = 3,
+        timeout_start_sec: float = 0.0,
     ) -> None:
         self.__func = func
         self.__autostart = autostart
         self.__task_instances: dict[object, Task[R]] = {}
+        self.__restart_on_failure = restart_on_failure
+        self.__restart_sec = restart_sec
+        self.__start_limit_interval_sec = start_limit_interval_sec
+        self.__start_limit_burst = start_limit_burst
+        self.__timeout_start_sec = timeout_start_sec
 
     def __set_name__(self, owner: type[DataService], name: str) -> None:
         """Stores the name of the task within the owning class. This method is called
@@ -67,14 +77,28 @@ class PerInstanceTaskDescriptor(Generic[R]):
         if instance not in self.__task_instances:
             self.__task_instances[instance] = instance._initialise_new_objects(
                 self.__task_name,
-                Task(self.__func.__get__(instance, owner), autostart=self.__autostart),
+                Task(
+                    self.__func.__get__(instance, owner),
+                    autostart=self.__autostart,
+                    restart_on_failure=self.__restart_on_failure,
+                    restart_sec=self.__restart_sec,
+                    start_limit_interval_sec=self.__start_limit_interval_sec,
+                    start_limit_burst=self.__start_limit_burst,
+                    timeout_start_sec=self.__timeout_start_sec,
+                ),
             )
 
         return self.__task_instances[instance]
 
 
-def task(
-    *, autostart: bool = False
+def task(  # noqa: PLR0913
+    *,
+    autostart: bool = False,
+    restart_on_failure: bool = False,
+    restart_sec: float = 1.0,
+    start_limit_interval_sec: float | None = None,
+    start_limit_burst: int = 3,
+    timeout_start_sec: float = 0.0,
 ) -> Callable[
     [
         Callable[[Any], Coroutine[None, None, R]]
@@ -96,13 +120,29 @@ def task(
     periodically or perform asynchronous operations, such as polling data sources,
     updating databases, or any recurring job that should be managed within the context
     of a `DataService`.
-    time.
+
+    The keyword arguments that can be passed to this decorator are inspired by systemd
+    unit services.
 
     Args:
         autostart:
             If set to True, the task will automatically start when the service is
             initialized. Defaults to False.
-
+        restart_on_failure:
+            Configures whether the task shall be restarted when it exits with an
+            exception other than [`asyncio.CancelledError`][asyncio.CancelledError].
+        restart_sec:
+            Configures the time to sleep before restarting a task. Defaults to 1.0.
+        start_limit_interval_sec:
+            Configures start rate limiting. Tasks which are started more than
+            `start_limit_burst` times within an `start_limit_interval_sec` time span are
+            not permitted to start any more. Defaults to None (disabled rate limiting).
+        start_limit_burst:
+            Configures unit start rate limiting. Tasks which are started more than
+            `start_limit_burst` times within an `start_limit_interval_sec` time span are
+            not permitted to start any more. Defaults to 3.
+        timeout_start_sec:
+            Configures the time to wait for start-up. Defaults to 0.0.
     Returns:
         A decorator that wraps an asynchronous function in a
         [`PerInstanceTaskDescriptor`][pydase.task.decorator.PerInstanceTaskDescriptor]
@@ -140,6 +180,14 @@ def task(
         func: Callable[[Any], Coroutine[None, None, R]]
         | Callable[[], Coroutine[None, None, R]],
     ) -> PerInstanceTaskDescriptor[R]:
-        return PerInstanceTaskDescriptor(func, autostart=autostart)
+        return PerInstanceTaskDescriptor(
+            func,
+            autostart=autostart,
+            restart_on_failure=restart_on_failure,
+            restart_sec=restart_sec,
+            start_limit_interval_sec=start_limit_interval_sec,
+            start_limit_burst=start_limit_burst,
+            timeout_start_sec=timeout_start_sec,
+        )
 
     return decorator

--- a/src/pydase/task/decorator.py
+++ b/src/pydase/task/decorator.py
@@ -30,13 +30,13 @@ class PerInstanceTaskDescriptor(Generic[R]):
         self,
         func: Callable[[Any], Coroutine[None, None, R]]
         | Callable[[], Coroutine[None, None, R]],
-        autostart: bool = False,
-        restart_on_failure: bool = False,
-        restart_sec: float = 1.0,
-        start_limit_interval_sec: float | None = None,
-        start_limit_burst: int = 3,
-        timeout_start_sec: float = 0.0,
-        exit_on_failure: bool = False,
+        autostart: bool,
+        restart_on_failure: bool,
+        restart_sec: float,
+        start_limit_interval_sec: float | None,
+        start_limit_burst: int,
+        timeout_start_sec: float,
+        exit_on_failure: bool,
     ) -> None:
         self.__func = func
         self.__autostart = autostart

--- a/src/pydase/task/task.py
+++ b/src/pydase/task/task.py
@@ -92,13 +92,13 @@ class Task(pydase.data_service.data_service.DataService, Generic[R]):
         self,
         func: Callable[[], Coroutine[None, None, R | None]],
         *,
-        autostart: bool = False,
-        restart_on_failure: bool = False,
-        restart_sec: float = 1.0,
-        start_limit_interval_sec: float | None = None,
-        start_limit_burst: int = 3,
-        timeout_start_sec: float = 0.0,
-        exit_on_failure: bool = False,
+        autostart: bool,
+        restart_on_failure: bool,
+        restart_sec: float,
+        start_limit_interval_sec: float | None,
+        start_limit_burst: int,
+        timeout_start_sec: float,
+        exit_on_failure: bool,
     ) -> None:
         super().__init__()
         self._autostart = autostart

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -384,25 +384,6 @@ async def test_non_exceeding_start_limit_interval_sec_and_burst(
 
 
 @pytest.mark.asyncio(scope="function")
-async def test_timeout_start_sec(caplog: LogCaptureFixture) -> None:
-    class MyService(pydase.DataService):
-        @task(timeout_start_sec=0.2)
-        async def my_task(self) -> None:
-            logger.info("Starting task.")
-            await asyncio.sleep(1)
-
-    service_instance = MyService()
-    state_manager = StateManager(service_instance)
-    DataServiceObserver(state_manager)
-    service_instance.my_task.start()
-
-    await asyncio.sleep(0.1)
-    assert "Starting task." not in caplog.text
-    await asyncio.sleep(0.2)
-    assert "Starting task." in caplog.text
-
-
-@pytest.mark.asyncio(scope="function")
 async def test_exit_on_failure(
     monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixture
 ) -> None:

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -423,7 +423,7 @@ async def test_exit_on_failure(
     service_instance.my_task.start()
 
     await asyncio.sleep(0.1)
-    assert "os.kill called with signal=15 and pid=" in caplog.text
+    assert "os.kill called with signal=" in caplog.text
     assert "Task 'my_task' encountered an exception" in caplog.text
 
 
@@ -453,5 +453,5 @@ async def test_exit_on_failure_exceeding_rate_limit(
     service_instance.my_task.start()
 
     await asyncio.sleep(0.5)
-    assert "os.kill called with signal=15 and pid=" in caplog.text
+    assert "os.kill called with signal=" in caplog.text
     assert "Task 'my_task' encountered an exception" in caplog.text

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -289,3 +289,169 @@ async def test_manual_start_with_multiple_service_instances(
     await asyncio.sleep(0.01)
 
     assert "Task 'my_task' was cancelled" in caplog.text
+
+
+@pytest.mark.asyncio(scope="function")
+async def test_restart_on_failure(caplog: LogCaptureFixture) -> None:
+    class MyService(pydase.DataService):
+        @task(restart_on_failure=True, restart_sec=0.1)
+        async def my_task(self) -> None:
+            logger.info("Triggered task.")
+            raise Exception("Task failure")
+
+    service_instance = MyService()
+    state_manager = StateManager(service_instance)
+    DataServiceObserver(state_manager)
+    service_instance.my_task.start()
+
+    await asyncio.sleep(0.01)
+    assert "Task 'my_task' encountered an exception" in caplog.text
+    caplog.clear()
+    await asyncio.sleep(0.1)
+    assert service_instance.my_task.status == TaskStatus.RUNNING
+    assert "Task 'my_task' encountered an exception" in caplog.text
+    assert "Triggered task." in caplog.text
+
+
+@pytest.mark.asyncio(scope="function")
+async def test_restart_sec(caplog: LogCaptureFixture) -> None:
+    class MyService(pydase.DataService):
+        @task(restart_on_failure=True, restart_sec=0.1)
+        async def my_task(self) -> None:
+            logger.info("Triggered task.")
+            raise Exception("Task failure")
+
+    service_instance = MyService()
+    state_manager = StateManager(service_instance)
+    DataServiceObserver(state_manager)
+    service_instance.my_task.start()
+
+    await asyncio.sleep(0.001)
+    assert "Triggered task." in caplog.text
+    caplog.clear()
+    await asyncio.sleep(0.05)
+    assert "Triggered task." not in caplog.text
+    await asyncio.sleep(0.05)
+    assert "Triggered task." in caplog.text  # Ensures the task restarted after 0.2s
+
+
+@pytest.mark.asyncio(scope="function")
+async def test_exceeding_start_limit_interval_sec_and_burst(
+    caplog: LogCaptureFixture,
+) -> None:
+    class MyService(pydase.DataService):
+        @task(
+            restart_on_failure=True,
+            restart_sec=0.0,
+            start_limit_interval_sec=1.0,
+            start_limit_burst=2,
+        )
+        async def my_task(self) -> None:
+            raise Exception("Task failure")
+
+    service_instance = MyService()
+    state_manager = StateManager(service_instance)
+    DataServiceObserver(state_manager)
+    service_instance.my_task.start()
+
+    await asyncio.sleep(0.1)
+    assert "Task 'my_task' exceeded restart burst limit" in caplog.text
+    assert service_instance.my_task.status == TaskStatus.NOT_RUNNING
+
+
+@pytest.mark.asyncio(scope="function")
+async def test_non_exceeding_start_limit_interval_sec_and_burst(
+    caplog: LogCaptureFixture,
+) -> None:
+    class MyService(pydase.DataService):
+        @task(
+            restart_on_failure=True,
+            restart_sec=0.1,
+            start_limit_interval_sec=0.1,
+            start_limit_burst=2,
+        )
+        async def my_task(self) -> None:
+            raise Exception("Task failure")
+
+    service_instance = MyService()
+    state_manager = StateManager(service_instance)
+    DataServiceObserver(state_manager)
+    service_instance.my_task.start()
+
+    await asyncio.sleep(0.5)
+    assert "Task 'my_task' exceeded restart burst limit" not in caplog.text
+    assert service_instance.my_task.status == TaskStatus.RUNNING
+
+
+@pytest.mark.asyncio(scope="function")
+async def test_timeout_start_sec(caplog: LogCaptureFixture) -> None:
+    class MyService(pydase.DataService):
+        @task(timeout_start_sec=0.2)
+        async def my_task(self) -> None:
+            logger.info("Starting task.")
+            await asyncio.sleep(1)
+
+    service_instance = MyService()
+    state_manager = StateManager(service_instance)
+    DataServiceObserver(state_manager)
+    service_instance.my_task.start()
+
+    await asyncio.sleep(0.1)
+    assert "Starting task." not in caplog.text
+    await asyncio.sleep(0.2)
+    assert "Starting task." in caplog.text
+
+
+@pytest.mark.asyncio(scope="function")
+async def test_exit_on_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixture
+) -> None:
+    class MyService(pydase.DataService):
+        @task(restart_on_failure=False, exit_on_failure=True)
+        async def my_task(self) -> None:
+            logger.info("Triggered task.")
+            raise Exception("Critical failure")
+
+    def mock_os_kill(pid: int, signal: int) -> None:
+        logger.critical("os.kill called with signal=%s and pid=%s", signal, pid)
+
+    monkeypatch.setattr("os.kill", mock_os_kill)
+
+    service_instance = MyService()
+    state_manager = StateManager(service_instance)
+    DataServiceObserver(state_manager)
+    service_instance.my_task.start()
+
+    await asyncio.sleep(0.1)
+    assert "os.kill called with signal=15 and pid=" in caplog.text
+    assert "Task 'my_task' encountered an exception" in caplog.text
+
+
+@pytest.mark.asyncio(scope="function")
+async def test_exit_on_failure_exceeding_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixture
+) -> None:
+    class MyService(pydase.DataService):
+        @task(
+            restart_on_failure=True,
+            restart_sec=0.0,
+            start_limit_interval_sec=0.1,
+            start_limit_burst=2,
+            exit_on_failure=True,
+        )
+        async def my_task(self) -> None:
+            raise Exception("Critical failure")
+
+    def mock_os_kill(pid: int, signal: int) -> None:
+        logger.critical("os.kill called with signal=%s and pid=%s", signal, pid)
+
+    monkeypatch.setattr("os.kill", mock_os_kill)
+
+    service_instance = MyService()
+    state_manager = StateManager(service_instance)
+    DataServiceObserver(state_manager)
+    service_instance.my_task.start()
+
+    await asyncio.sleep(0.5)
+    assert "os.kill called with signal=15 and pid=" in caplog.text
+    assert "Task 'my_task' encountered an exception" in caplog.text


### PR DESCRIPTION
Implements #22 and #193.

- [x] Add tests
- [x] Add documentation

This PR adds the following options (inspired by systemd unit services) to the `@task` decorator:
- **`restart_on_failure`**: Configures whether the task should restart if it exits due to an exception (other than `asyncio.CancelledError`). Defaults to `True`.
- **`restart_sec`**: Specifies the delay (in seconds) before restarting a failed task. Defaults to `1.0`.
- **`start_limit_interval_sec`**: Configures a time window (in seconds) for rate limiting task restarts. If the task restarts more than `start_limit_burst` times within this interval, it will no longer restart. Defaults to `None` (disabled).
- **`start_limit_burst`**: Defines the maximum number of restarts allowed within the interval specified by `start_limit_interval_sec`. Defaults to `3`.
- **`exit_on_failure`**: If set to `True`, the service will exit if the task fails and either `restart_on_failure` is `False` or the start rate limiting is exceeded. Defaults to `False`.

You can use it like so:

```python
import pydase
from pydase.task.decorator import task


class AdvancedTaskService(pydase.DataService):
    def __init__(self):
        super().__init__()

    @task(
        autostart=True,
        restart_on_failure=True,
        restart_sec=2.0,
        start_limit_interval_sec=10.0,
        start_limit_burst=5,
        exit_on_failure=True,
    )
    async def critical_task(self):
        while True:
            raise Exception("Critical failure")


if __name__ == "__main__":
    service = AdvancedTaskService()
    pydase.Server(service=service).run()
```