### PR TITLE
fix: return result of task after finishing gracefully

### DIFF
--- a/src/pydase/task/task.py
+++ b/src/pydase/task/task.py
@@ -169,7 +169,7 @@ class Task(pydase.data_service.data_service.DataService, Generic[R]):
 
         while True:
             try:
-                await self._func()
+                return await self._func()
             except asyncio.CancelledError:
                 logger.info("Task '%s' was cancelled", self._func_name)
                 raise


### PR DESCRIPTION
Tasks that finished gracefully were restarted again. This MR fixes that.