### PR TITLE
fix: serves modified index.html (X-Forwarded-Proto) when X-Forwarded-Prefix is not set

### DIFF
--- a/src/pydase/server/web_server/web_server.py
+++ b/src/pydase/server/web_server/web_server.py
@@ -150,10 +150,7 @@ class WebServer:
                     f"{escaped_prefix}/favicon.ico",
                 )
 
-                return aiohttp.web.Response(
-                    text=modified_html, content_type="text/html"
-                )
-            return aiohttp.web.FileResponse(self.frontend_src / "index.html")
+            return aiohttp.web.Response(text=modified_html, content_type="text/html")
 
         app = aiohttp.web.Application()
 


### PR DESCRIPTION
When X-Forwarded-Prefix was not set, the X-Forwarded-Proto was also not updated on the index.html file. This MR fixes this.