### PR TITLE
Feat: autosaving feature

### DIFF
--- a/docs/dev-guide/api.md
+++ b/docs/dev-guide/api.md
@@ -1,6 +1,15 @@
 ::: pydase.data_service
     handler: python
 
+::: pydase.data_service.data_service_cache
+    handler: python
+
+::: pydase.data_service.data_service_observer
+    handler: python
+
+::: pydase.data_service.state_manager
+    handler: python
+
 ::: pydase.server.server
     handler: python
 

--- a/docs/user-guide/Service_Persistence.md
+++ b/docs/user-guide/Service_Persistence.md
@@ -2,29 +2,47 @@
 
 `pydase` allows you to easily persist the state of your service by saving it to a file. This is especially useful when you want to maintain the service's state across different runs.
 
-To save the state of your service, pass a `filename` keyword argument to the constructor of the `pydase.Server` class. If the file specified by `filename` does not exist, the state manager will create this file and store its state in it when the service is shut down. If the file already exists, the state manager will load the state from this file, setting the values of its attributes to the values stored in the file.
+To enable persistence, pass a `filename` keyword argument to the constructor of the [`pydase.Server`][pydase.Server] class. The `filename` specifies the file where the state will be saved:
 
-Here's an example:
+- If the file **does not exist**, it will be created and populated with the current state when the service shuts down or saves.
+- If the file **already exists**, the state manager will **load** the saved values into the service at startup.
+
+Here’s an example:
 
 ```python
 import pydase
 
 class Device(pydase.DataService):
-    # ... defining the Device class ...
-
+    # ... define your service class ...
 
 if __name__ == "__main__":
     service = Device()
     pydase.Server(service=service, filename="device_state.json").run()
 ```
 
-In this example, the state of the `Device` service will be saved to `device_state.json` when the service is shut down. If `device_state.json` exists when the server is started, the state manager will restore the state of the service from this file.
+In this example, the service state will be automatically loaded from `device_state.json` at startup (if it exists), and saved to the same file periodically and upon shutdown.
+
+## Automatic Periodic State Saving
+
+When a `filename` is provided, `pydase` automatically enables **periodic autosaving** of the service state to that file. This ensures that the current state is regularly persisted, reducing the risk of data loss during unexpected shutdowns.
+
+The autosave happens every 30 seconds by default. You can customize the interval using the `autosave_interval` argument (in seconds):
+
+```python
+pydase.Server(
+    service=service,
+    filename="device_state.json",
+    autosave_interval=10.0,  # save every 10 seconds
+).run()
+```
+
+To disable automatic saving, set `autosave_interval` to `None`.
 
 ## Controlling Property State Loading with `@load_state`
 
-By default, the state manager only restores values for public attributes of your service. If you have properties that you want to control the loading for, you can use the `@load_state` decorator on your property setters. This indicates to the state manager that the value of the property should be loaded from the state file.
+By default, the state manager only restores values for public attributes of your service (i.e. *it does not restore property values*). If you have properties that you want to control the loading for, you can use the [`@load_state`][pydase.data_service.state_manager.load_state] decorator on your property setters. This indicates to the state manager that the value of the property should be loaded from the state file.
 
-Here is how you can apply the `@load_state` decorator:
+Example:
 
 ```python
 import pydase
@@ -43,7 +61,6 @@ class Device(pydase.DataService):
         self._name = value
 ```
 
-With the `@load_state` decorator applied to the `name` property setter, the state manager will load and apply the `name` property's value from the file storing the state upon server startup, assuming it exists.
+With the `@load_state` decorator applied to the `name` property setter, the state manager will load and apply the `name` property's value from the file upon server startup.
 
-Note: If the service class structure has changed since the last time its state was saved, only the attributes and properties decorated with `@load_state` that have remained the same will be restored from the settings file.
-
+**Note**: If the structure of your service class changes between saves, only properties decorated with `@load_state` and unchanged public attributes will be restored safely.

--- a/src/pydase/data_service/data_service_cache.py
+++ b/src/pydase/data_service/data_service_cache.py
@@ -14,6 +14,22 @@ logger = logging.getLogger(__name__)
 
 
 class DataServiceCache:
+    """Maintains a serialized cache of the current state of a DataService instance.
+
+    This class is responsible for storing and updating a representation of the service's
+    public attributes and properties. It is primarily used by the StateManager and the
+    web server to serve consistent state to clients without accessing the DataService
+    attributes directly.
+
+    The cache is initialized once upon construction by serializing the full state of
+    the service. After that, it can be incrementally updated using attribute paths and
+    values as notified by the
+    [`DataServiceObserver`][pydase.data_service.data_service_observer.DataServiceObserver].
+
+    Args:
+        service: The DataService instance whose state should be cached.
+    """
+
     def __init__(self, service: "DataService") -> None:
         self._cache: SerializedObject
         self.service = service

--- a/src/pydase/data_service/state_manager.py
+++ b/src/pydase/data_service/state_manager.py
@@ -73,7 +73,8 @@ class StateManager:
 
     The StateManager is used by the web server to apply updates to service attributes
     and to serve the current state to newly connected clients. Internally, it creates a
-    `DataServiceCache` instance to track the state of public attributes and properties.
+    [`DataServiceCache`][pydase.data_service.data_service_cache.DataServiceCache]
+    instance to track the state of public attributes and properties.
 
     The StateManager also handles state persistence: it can load a previously saved
     state from disk at startup and periodically autosave the current state to a file

--- a/src/pydase/data_service/state_manager.py
+++ b/src/pydase/data_service/state_manager.py
@@ -99,8 +99,8 @@ class StateManager:
     def __init__(
         self,
         service: "DataService",
-        filename: str | Path | None,
-        autosave_interval: float | None,
+        filename: str | Path | None = None,
+        autosave_interval: float | None = None,
     ) -> None:
         self.filename = getattr(service, "_filename", None)
 


### PR DESCRIPTION
Implements #44.
When a filename was provided to the `pydase.Server`, it will periodically save the service state to the specified file. The interval between the save events can be configured using the `autosave_interval` argument passed to the server:

```python
pydase.Server(
    service=service,
    filename="device_state.json",
    autosave_interval=10.0,  # save every 10 seconds
).run()
```