### PR TITLE
fix: correctly handle observable properties

### DIFF
--- a/src/pydase/observer_pattern/observable/observable.py
+++ b/src/pydase/observer_pattern/observable/observable.py
@@ -55,6 +55,10 @@ class Observable(ObservableObject):
         value = super().__getattribute__(name)
 
         if is_property_attribute(self, name):
+            # fixes https://github.com/tiqi-group/pydase/issues/187 and
+            # https://github.com/tiqi-group/pydase/issues/192
+            if isinstance(value, ObservableObject):
+                value.add_observer(self, name)
             self._notify_changed(name, value)
 
         return value

--- a/tests/data_service/test_data_service_observer.py
+++ b/tests/data_service/test_data_service_observer.py
@@ -222,3 +222,22 @@ def test_nested_dict_property_changes(
     # Changing the _voltage attribute should re-evaluate the voltage property, but avoid
     # recursion
     service.my_dict["key"].voltage = 1.2
+
+
+def test_read_only_dict_property(caplog: pytest.LogCaptureFixture) -> None:
+    class MyObservable(pydase.DataService):
+        def __init__(self) -> None:
+            super().__init__()
+            self._dict_attr = {"dotted.key": 1.0}
+
+        @property
+        def dict_attr(self) -> dict[str, Any]:
+            return self._dict_attr
+
+    service_instance = MyObservable()
+    state_manager = StateManager(service=service_instance)
+    DataServiceObserver(state_manager)
+
+    service_instance._dict_attr["dotted.key"] = 2.0
+
+    assert "'dict_attr[\"dotted.key\"]' changed to '2.0'" in caplog.text


### PR DESCRIPTION
When an observable is returned by a property, the parent object will be added as an observer to the observable. This fixes #187 and #192.