### PR TITLE
feat (config): changes web_port loading

### DIFF
--- a/src/pydase/server/server.py
+++ b/src/pydase/server/server.py
@@ -87,8 +87,10 @@ class Server:
         service: The DataService instance that this server will manage.
         host: The host address for the server. Defaults to `'0.0.0.0'`, which means all
             available network interfaces.
-        web_port: The port number for the web server. Defaults to
-            [`ServiceConfig().web_port`][pydase.config.ServiceConfig.web_port].
+        web_port: The port number for the web server. If set to None, it will use the
+            port defined in
+            [`ServiceConfig().web_port`][pydase.config.ServiceConfig.web_port]. Defaults
+            to None.
         enable_web: Whether to enable the web server.
         filename: Filename of the file managing the service state persistence.
         additional_servers: A list of additional servers to run alongside the main
@@ -140,7 +142,7 @@ class Server:
         self,
         service: DataService,
         host: str = "0.0.0.0",
-        web_port: int = ServiceConfig().web_port,
+        web_port: int | None = None,
         enable_web: bool = True,
         filename: str | Path | None = None,
         additional_servers: list[AdditionalServer] | None = None,
@@ -151,7 +153,10 @@ class Server:
             additional_servers = []
         self._service = service
         self._host = host
-        self._web_port = web_port
+        if web_port is None:
+            self._web_port = ServiceConfig().web_port
+        else:
+            self._web_port = web_port
         self._enable_web = enable_web
         self._kwargs = kwargs
         self._additional_servers = additional_servers


### PR DESCRIPTION
The web_port argument in the pydase.Server defaults to None now. If it is None, the value from ServiceConfig().web_port will be used. This fixes the issue where users might pass the web port dynamcially and by passing None they want to use the default value.