### PR TITLE
chore: properly closing event loops in client and server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,10 @@ disallow_incomplete_defs = true
 disallow_any_generics = true
 check_untyped_defs = true
 ignore_missing_imports = false
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
+filterwarnings = [
+    # I don't controll the usage of the timeout
+    "ignore:parameter 'timeout' of type 'float' is deprecated, please use 'timeout=ClientWSTimeout"
+]

--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -33,7 +33,10 @@ class NotifyDict(TypedDict):
 
 def asyncio_loop_thread(loop: asyncio.AbstractEventLoop) -> None:
     asyncio.set_event_loop(loop)
-    loop.run_forever()
+    try:
+        loop.run_forever()
+    finally:
+        loop.close()
 
 
 class Client:

--- a/src/pydase/server/server.py
+++ b/src/pydase/server/server.py
@@ -182,7 +182,10 @@ class Server:
 
         This method should be called to start the server after it's been instantiated.
         """
-        self._loop.run_until_complete(self.serve())
+        try:
+            self._loop.run_until_complete(self.serve())
+        finally:
+            self._loop.close()
 
     async def serve(self) -> None:
         process_id = os.getpid()

--- a/src/pydase/utils/helpers.py
+++ b/src/pydase/utils/helpers.py
@@ -219,7 +219,18 @@ def is_descriptor(obj: object) -> bool:
 
 
 def current_event_loop_exists() -> bool:
-    """Check if an event loop has been set."""
+    """Check if a running and open asyncio event loop exists in the current thread.
+
+    This checks if an event loop is set via the current event loop policy and verifies
+    that the loop has not been closed.
+
+    Returns:
+        True if an event loop exists and is not closed, False otherwise.
+    """
+
     import asyncio
 
-    return asyncio.get_event_loop_policy()._local._loop is not None  # type: ignore
+    try:
+        return not asyncio.get_running_loop().is_closed()
+    except RuntimeError:
+        return False

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -2,8 +2,9 @@ import threading
 from collections.abc import Generator
 from typing import Any
 
-import pydase
 import pytest
+
+import pydase
 from pydase.client.proxy_loader import ProxyAttributeError
 
 
@@ -52,6 +53,7 @@ def pydase_client() -> Generator[pydase.Client, None, Any]:
 
     yield client
 
+    client.disconnect()
     server.handle_exit()
     thread.join()
 

--- a/tests/client/test_reconnection.py
+++ b/tests/client/test_reconnection.py
@@ -2,27 +2,26 @@ import threading
 from collections.abc import Callable, Generator
 from typing import Any
 
-import pydase
 import pytest
 import socketio.exceptions
 
+import pydase
+
 
 @pytest.fixture(scope="function")
-def pydase_restartable_server() -> (
-    Generator[
-        tuple[
-            pydase.Server,
-            threading.Thread,
-            pydase.DataService,
-            Callable[
-                [pydase.Server, threading.Thread, pydase.DataService],
-                tuple[pydase.Server, threading.Thread],
-            ],
+def pydase_restartable_server() -> Generator[
+    tuple[
+        pydase.Server,
+        threading.Thread,
+        pydase.DataService,
+        Callable[
+            [pydase.Server, threading.Thread, pydase.DataService],
+            tuple[pydase.Server, threading.Thread],
         ],
-        None,
-        Any,
-    ]
-):
+    ],
+    None,
+    Any,
+]:
     class MyService(pydase.DataService):
         def __init__(self) -> None:
             super().__init__()
@@ -61,9 +60,6 @@ def pydase_restartable_server() -> (
         return server, new_thread
 
     yield server, thread, service_instance, restart
-
-    server.handle_exit()
-    thread.join()
 
 
 def test_reconnection(
@@ -105,3 +101,6 @@ def test_reconnection(
     # the service proxies successfully reconnect and get the new service name
     assert client.proxy.name == "New service name"
     assert client_2.proxy.name == "New service name"
+
+    server.handle_exit()
+    thread.join()

--- a/tests/components/test_device_connection.py
+++ b/tests/components/test_device_connection.py
@@ -7,7 +7,7 @@ from pydase.task.autostart import autostart_service_tasks
 from pytest import LogCaptureFixture
 
 
-@pytest.mark.asyncio(scope="function")
+@pytest.mark.asyncio(loop_scope="function")
 async def test_reconnection(caplog: LogCaptureFixture) -> None:
     class MyService(pydase.components.device_connection.DeviceConnection):
         def __init__(

--- a/tests/server/web_server/api/v1/test_endpoints.py
+++ b/tests/server/web_server/api/v1/test_endpoints.py
@@ -4,12 +4,13 @@ from collections.abc import Generator
 from typing import Any
 
 import aiohttp
-import pydase
 import pytest
+
+import pydase
 from pydase.utils.serialization.deserializer import Deserializer
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def pydase_server() -> Generator[None, None, None]:
     class SubService(pydase.DataService):
         name = "SubService"
@@ -51,6 +52,9 @@ def pydase_server() -> Generator[None, None, None]:
     thread.start()
 
     yield
+
+    server.handle_exit()
+    thread.join()
 
 
 @pytest.mark.parametrize(
@@ -107,7 +111,7 @@ def pydase_server() -> Generator[None, None, None]:
         ),
     ],
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio(loop_scope="module")
 async def test_get_value(
     access_path: str,
     expected: dict[str, Any],
@@ -179,7 +183,7 @@ async def test_get_value(
         ),
     ],
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio(loop_scope="module")
 async def test_update_value(
     access_path: str,
     new_value: dict[str, Any],
@@ -219,7 +223,7 @@ async def test_update_value(
         ),
     ],
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio(loop_scope="module")
 async def test_trigger_method(
     access_path: str,
     expected: Any,
@@ -278,7 +282,7 @@ async def test_trigger_method(
         ),
     ],
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio(loop_scope="module")
 async def test_client_information_logging(
     headers: dict[str, str],
     log_id: str,

--- a/tests/server/web_server/test_sio_setup.py
+++ b/tests/server/web_server/test_sio_setup.py
@@ -2,13 +2,14 @@ import threading
 from collections.abc import Generator
 from typing import Any
 
-import pydase
 import pytest
 import socketio
+
+import pydase
 from pydase.utils.serialization.deserializer import Deserializer
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def pydase_server() -> Generator[None, None, None]:
     class SubService(pydase.DataService):
         name = "SubService"
@@ -50,6 +51,9 @@ def pydase_server() -> Generator[None, None, None]:
     thread.start()
 
     yield
+
+    server.handle_exit()
+    thread.join()
 
 
 @pytest.mark.parametrize(
@@ -106,7 +110,7 @@ def pydase_server() -> Generator[None, None, None]:
         ),
     ],
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio(loop_scope="module")
 async def test_get_value(
     access_path: str,
     expected: dict[str, Any],
@@ -181,7 +185,7 @@ async def test_get_value(
         ),
     ],
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio(loop_scope="module")
 async def test_update_value(
     access_path: str,
     new_value: dict[str, Any],
@@ -226,7 +230,7 @@ async def test_update_value(
         ),
     ],
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio(loop_scope="module")
 async def test_trigger_method(
     access_path: str,
     expected: Any,
@@ -291,7 +295,7 @@ async def test_trigger_method(
         ),
     ],
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio(loop_scope="module")
 async def test_client_information_logging(
     headers: dict[str, str],
     log_id: str,

--- a/tests/utils/serialization/test_serializer.py
+++ b/tests/utils/serialization/test_serializer.py
@@ -207,7 +207,7 @@ def test_ColouredEnum_serialize() -> None:
     }
 
 
-@pytest.mark.asyncio(scope="module")
+@pytest.mark.asyncio(loop_scope="module")
 async def test_method_serialization() -> None:
     class ClassWithMethod(pydase.DataService):
         def some_method(self) -> str:


### PR DESCRIPTION
These changes ensure that `asyncio` event loops are properly closed after use, preventing resource leaks and warnings like `RuntimeError: Cannot close a running event loop `or `Task was destroyed but it is pending!`. By closing the event loop in both the server and client threads, the system shuts down cleanly. This was mainly observed in tests.