### PR TITLE
fix: using client without aiohttp_socks dependency does not raise

### DIFF
--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -1,9 +1,9 @@
-from builtins import ModuleNotFoundError
 import asyncio
 import logging
 import sys
 import threading
 import urllib.parse
+from builtins import ModuleNotFoundError
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 

--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -1,3 +1,4 @@
+from builtins import ModuleNotFoundError
 import asyncio
 import logging
 import sys
@@ -7,7 +8,6 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import aiohttp
-import aiohttp_socks.connector
 import socketio  # type: ignore
 
 from pydase.client.proxy_class import ProxyClass
@@ -150,6 +150,17 @@ class Client:
 
     def _initialize_socketio_client(self) -> None:
         if self._proxy_url is not None:
+            try:
+                import aiohttp_socks.connector
+            except ModuleNotFoundError:
+                raise ModuleNotFoundError(
+                    "Missing dependency 'aiohttp_socks'. To use SOCKS5 proxy support, "
+                    "install the optional 'socks' extra:\n\n"
+                    '    pip install "pydase[socks]"\n\n'
+                    "This is required when specifying a `proxy_url` for "
+                    "`pydase.Client`."
+                )
+
             session = aiohttp.ClientSession(
                 connector=aiohttp_socks.connector.ProxyConnector.from_url(
                     url=self._proxy_url, loop=self._loop


### PR DESCRIPTION
When not specifying the proxy_url in `pydase.Client`, the aiohttp_socks dependency is not required. This is now handled by putting the import into the correct place, adding a descriptive log message when the import fails.