### PR TITLE
Fix: property dependency function argument

### DIFF
--- a/src/pydase/observer_pattern/observer/property_observer.py
+++ b/src/pydase/observer_pattern/observer/property_observer.py
@@ -22,7 +22,7 @@ def reverse_dict(original_dict: dict[str, list[str]]) -> dict[str, list[str]]:
 
 def get_property_dependencies(prop: property, prefix: str = "") -> list[str]:
     source_code_string = inspect.getsource(prop.fget)  # type: ignore[arg-type]
-    pattern = r"self\.([^\s\{\}\)]+)"
+    pattern = r"self\.([^\s\{\}\(\)]+)"
     matches = re.findall(pattern, source_code_string)
     return [prefix + match for match in matches if "(" not in match]
 

--- a/src/pydase/observer_pattern/observer/property_observer.py
+++ b/src/pydase/observer_pattern/observer/property_observer.py
@@ -22,7 +22,7 @@ def reverse_dict(original_dict: dict[str, list[str]]) -> dict[str, list[str]]:
 
 def get_property_dependencies(prop: property, prefix: str = "") -> list[str]:
     source_code_string = inspect.getsource(prop.fget)  # type: ignore[arg-type]
-    pattern = r"self\.([^\s\{\}]+)"
+    pattern = r"self\.([^\s\{\}\)]+)"
     matches = re.findall(pattern, source_code_string)
     return [prefix + match for match in matches if "(" not in match]
 

--- a/tests/data_service/test_data_service_observer.py
+++ b/tests/data_service/test_data_service_observer.py
@@ -245,19 +245,20 @@ def test_read_only_dict_property(caplog: pytest.LogCaptureFixture) -> None:
 
 
 def test_dependency_as_function_argument(caplog: pytest.LogCaptureFixture) -> None:
-    import time
-
     class MyObservable(pydase.DataService):
-        time_ms = 0
+        some_int = 0
 
         @property
-        def datetime(self) -> str:
-            return time.ctime(self.time_ms)
+        def other_int(self) -> int:
+            return self.add_one(self.some_int)
+
+        def add_one(self, value: int) -> int:
+            return value + 1
 
     service_instance = MyObservable()
     state_manager = StateManager(service=service_instance)
     DataServiceObserver(state_manager)
 
-    service_instance.time_ms = 1746136800
+    service_instance.some_int = 1337
 
-    assert "'datetime' changed to 'Fri May  2 00:00:00 2025'" in caplog.text
+    assert "'other_int' changed to '1338'" in caplog.text


### PR DESCRIPTION
This fixes the first problem in issue #230. Given the following example:

```python
import time

import pydase


class TimeDisplay(pydase.DataService):
    time_ms = 0.0

    @property
    def datetime(self) -> str:
        return time.ctime(self.time_ms)


if __name__ == "__main__":
    pydase.Server(TimeDisplay()).run()
```

the `get_property_dependencies` function correctly matches `time_ms` instead of `time_ms)` now.