### PR TITLE
fix: task event loop

### DIFF
--- a/src/pydase/server/server.py
+++ b/src/pydase/server/server.py
@@ -14,7 +14,6 @@ from pydase.data_service.data_service_observer import DataServiceObserver
 from pydase.data_service.state_manager import StateManager
 from pydase.server.web_server import WebServer
 from pydase.task.autostart import autostart_service_tasks
-from pydase.utils.helpers import current_event_loop_exists
 
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
@@ -162,6 +161,10 @@ class Server:
         self._additional_servers = additional_servers
         self.should_exit = False
         self.servers: dict[str, asyncio.Future[Any]] = {}
+
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+
         self._state_manager = StateManager(
             service=self._service,
             filename=filename,
@@ -170,11 +173,6 @@ class Server:
         self._observer = DataServiceObserver(self._state_manager)
         self._state_manager.load_state()
         autostart_service_tasks(self._service)
-        if not current_event_loop_exists():
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
-        else:
-            self._loop = asyncio.get_event_loop()
 
     def run(self) -> None:
         """

--- a/src/pydase/utils/helpers.py
+++ b/src/pydase/utils/helpers.py
@@ -231,6 +231,6 @@ def current_event_loop_exists() -> bool:
     import asyncio
 
     try:
-        return not asyncio.get_running_loop().is_closed()
+        return not asyncio.get_event_loop().is_closed()
     except RuntimeError:
         return False


### PR DESCRIPTION
The `current_event_loop_exists` function was getting the running event loop to check if there was one. This does not return the event loop set through `asyncio.set_event_loop`, so the tasks did not get the event loop that is later startet by the `pydase.Server`.
This MR updates this function to call `get_event_loop` instead of `get_running_loop` and updates `pydase.Server` s.t. it gets a new event loop on startup, as there shouldn't be any other loop running yet.