### PR TITLE
feat: adds client id default

### DIFF
--- a/docs/user-guide/interaction/Python-Client.md
+++ b/docs/user-guide/interaction/Python-Client.md
@@ -58,7 +58,7 @@ class MyService(pydase.DataService):
     proxy = pydase.Client(
         url="ws://<ip_addr>:<service_port>",
         block_until_connected=False,
-        client_id="my_pydase_client_id",
+        client_id="my_pydase_client_id",  # optional, defaults to system hostname
     ).proxy
 
     # For SSL-encrypted services, use the wss protocol
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 In this example:
 - The `MyService` class has a `proxy` attribute that connects to a `pydase` service at `<ip_addr>:<service_port>`.
 - By setting `block_until_connected=False`, the service can start without waiting for the connection to succeed.
-- By setting `client_id`, the server will log a descriptive identifier for this client via the `X-Client-Id` HTTP header.
+- The `client_id` is optional. If not specified, it defaults to the system hostname, which will be sent in the `X-Client-Id` HTTP header for logging or authentication on the server side.
 
 ## Custom `socketio.AsyncClient` Connection Parameters
 

--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import socket
 import sys
 import threading
 import urllib.parse
@@ -59,7 +60,8 @@ class Client:
             client's behaviour (e.g., reconnection attempts or reconnection delay).
         client_id: An optional client identifier. This ID is sent to the server as the
             `X-Client-Id` HTTP header. It can be used for logging or authentication
-            purposes on the server side.
+            purposes on the server side. If not provided, it defaults to the hostname
+            of the machine running the client.
         proxy_url: An optional proxy URL to route the connection through. This is useful
             if the service is only reachable via an SSH tunnel or behind a firewall
             (e.g., `socks5://localhost:2222`).
@@ -112,7 +114,7 @@ class Client:
         self._path_prefix = parsed_url.path.rstrip("/")  # Remove trailing slash if any
         self._url = url
         self._proxy_url = proxy_url
-        self._client_id = client_id
+        self._client_id = client_id or socket.gethostname()
         self._sio_client_kwargs = sio_client_kwargs
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -168,9 +168,11 @@ def test_context_manager(pydase_client: pydase.Client) -> None:
 def test_client_id(
     pydase_client: pydase.Client, caplog: pytest.LogCaptureFixture
 ) -> None:
+    import socket
+
     pydase.Client(url="ws://localhost:9999")
 
-    assert "Client [sid=" in caplog.text
+    assert f"Client [id={socket.gethostname()}]" in caplog.text
     caplog.clear()
 
     pydase.Client(url="ws://localhost:9999", client_id="my_service")


### PR DESCRIPTION
This MR adds the hostname of the client as client_id default. This is used for logging on the server side.