### PR TITLE
fix: check if loop is running in SocketIOHandler

### DIFF
--- a/src/pydase/utils/logging.py
+++ b/src/pydase/utils/logging.py
@@ -165,15 +165,16 @@ class SocketIOHandler(logging.Handler):
         log_entry = self.format(record)
 
         loop = asyncio.get_event_loop()
-        loop.create_task(
-            self._sio.emit(
-                "log",
-                {
-                    "levelname": record.levelname,
-                    "message": log_entry,
-                },
+        if loop.is_running():
+            loop.create_task(
+                self._sio.emit(
+                    "log",
+                    {
+                        "levelname": record.levelname,
+                        "message": log_entry,
+                    },
+                )
             )
-        )
 
 
 def setup_logging() -> None:


### PR DESCRIPTION
Before emitting sio events in the SocketIOHandler, I have to check if the loop is actually still running. This caused issues with `pytest` as it was tearing down asyncio tasks and stopping the loop, while the sio handler was still trying to send those logs to the sio clients.