### PR TITLE
Refactor: web server initialisation

### DIFF
--- a/src/pydase/server/web_server/sio_setup.py
+++ b/src/pydase/server/web_server/sio_setup.py
@@ -115,7 +115,7 @@ def setup_sio_server(
     def sio_callback(
         full_access_path: str, value: Any, cached_value_dict: SerializedObject
     ) -> None:
-        if cached_value_dict != {}:
+        if cached_value_dict != {} and loop.is_running():
 
             async def notify() -> None:
                 try:

--- a/src/pydase/server/web_server/web_server.py
+++ b/src/pydase/server/web_server/web_server.py
@@ -105,13 +105,11 @@ class WebServer:
 
         self._service_config_dir = config_dir
         self._generate_web_settings = generate_web_settings
-        self._loop: asyncio.AbstractEventLoop
+        self._loop = asyncio.get_event_loop()
+        self._sio = setup_sio_server(self.observer, self.enable_cors, self._loop)
         self._initialise_configuration()
 
     async def serve(self) -> None:
-        self._loop = asyncio.get_running_loop()
-        self._sio = setup_sio_server(self.observer, self.enable_cors, self._loop)
-
         async def index(
             request: aiohttp.web.Request,
         ) -> aiohttp.web.Response | aiohttp.web.FileResponse:


### PR DESCRIPTION
The `WebServer` can be initialised in the `pydase.Server` constructor without any problems. This would allow users to access it before starting the `pydase.Server`. This is, e.g., useful if you want to perform custom logic using the `socketio.AsyncServer`.