### PR TITLE
feat: improve client proxy serialization

### DIFF
--- a/src/pydase/client/client.py
+++ b/src/pydase/client/client.py
@@ -240,12 +240,11 @@ class Client:
             self.proxy, serialized_object=serialized_object
         )
         serialized_object["type"] = "DeviceConnection"
-        if self.proxy._service_representation is not None:
-            # need to use object.__setattr__ to not trigger an observer notification
-            object.__setattr__(self.proxy, "_service_representation", serialized_object)
+        # need to use object.__setattr__ to not trigger an observer notification
+        object.__setattr__(self.proxy, "_service_representation", serialized_object)
 
-            if TYPE_CHECKING:
-                self.proxy._service_representation = serialized_object  # type: ignore
+        if TYPE_CHECKING:
+            self.proxy._service_representation = serialized_object  # type: ignore
         self.proxy._notify_changed("", self.proxy)
         self.proxy._connected = True
 


### PR DESCRIPTION
The proxy needs to properly handle serialization requests. If such a requests comes from the `asyncio` loop used by the `socketio` client, this would result in a deadlock. This happens, for example, when the observer is notified of a change triggered within a `socketio` event. To prevent this, I am checking the current loop against the `socketio` client loop. If it's the same, return the `_service_representation` value, which is set when `pydase.Client` connects to the server. I do the same when the client is not connected (to prevent `BadNamespaceError`s).
Every other invocation of `serialize` results in an API call to the server.