### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tiqi-group/pydase/security/code-scanning/4](https://github.com/tiqi-group/pydase/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly define the minimal permissions required for the workflow to function. Based on the tasks performed in the workflow (e.g., installing dependencies, running tests, and linting), the `contents: read` permission is sufficient. This ensures that the workflow can read the repository contents but cannot perform any write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
