### PR TITLE
fix: race-condition in PropertyObserver

### DIFF
--- a/src/pydase/observer_pattern/observer/property_observer.py
+++ b/src/pydase/observer_pattern/observer/property_observer.py
@@ -29,6 +29,7 @@ def get_property_dependencies(prop: property, prefix: str = "") -> list[str]:
 
 class PropertyObserver(Observer):
     def __init__(self, observable: Observable) -> None:
+        self.property_deps_dict: dict[str, list[str]] = {}
         super().__init__(observable)
         self._update_property_deps_dict()
 


### PR DESCRIPTION
When a proxy of a pydase client initialised with `block_until_connected=False` is set as an attribute of a data service, a race condition can happen: when the client connects while the `DataServiceObserver` is being initialised, the `property_deps_dict` attribute might not be set yet while the `DataServiceObserver` was already added as an observer to the client proxy. The proxy will then emit a notification, which in turn tries to get the dependent properties from the `property_deps_dict` attribute, which has not been initialised yet. The resulting exception prevents the proxy to learn that the client has connected.