### PR TITLE
removes _warn_on_type_change from DataService setattr

### DIFF
--- a/src/pydase/data_service/data_service.py
+++ b/src/pydase/data_service/data_service.py
@@ -12,7 +12,6 @@ from pydase.observer_pattern.observable.observable import (
 from pydase.utils.helpers import (
     get_class_and_instance_attributes,
     is_descriptor,
-    is_property_attribute,
 )
 from pydase.utils.serialization.serializer import (
     Serializer,
@@ -28,9 +27,6 @@ class DataService(AbstractDataService):
         self.__check_instance_classes()
 
     def __setattr__(self, name: str, value: Any, /) -> None:
-        # Check and warn for unexpected type changes in attributes
-        self._warn_on_type_change(name, value)
-
         # every class defined by the user should inherit from DataService if it is
         # assigned to a public attribute
         if not name.startswith("_") and not inspect.isfunction(value):
@@ -38,21 +34,6 @@ class DataService(AbstractDataService):
 
         # Set the attribute
         super().__setattr__(name, value)
-
-    def _warn_on_type_change(self, attr_name: str, new_value: Any) -> None:
-        if is_property_attribute(self, attr_name):
-            return
-
-        current_value = getattr(self, attr_name, None)
-        if self._is_unexpected_type_change(current_value, new_value):
-            logger.warning(
-                "Type of '%s' changed from '%s' to '%s'. This may have unwanted "
-                "side effects! Consider setting it to '%s' directly.",
-                attr_name,
-                type(current_value).__name__,
-                type(new_value).__name__,
-                type(current_value).__name__,
-            )
 
     def _is_unexpected_type_change(self, current_value: Any, new_value: Any) -> bool:
         return (

--- a/tests/data_service/test_data_service.py
+++ b/tests/data_service/test_data_service.py
@@ -1,38 +1,13 @@
 from enum import Enum
 from typing import Any
 
-import pydase
-import pydase.units as u
 import pytest
-from pydase import DataService
-from pydase.data_service.data_service_observer import DataServiceObserver
-from pydase.data_service.state_manager import StateManager
-from pydase.utils.decorators import FunctionDefinitionError, frontend
 from pytest import LogCaptureFixture
 
-
-def test_unexpected_type_change_warning(caplog: LogCaptureFixture) -> None:
-    class ServiceClass(DataService):
-        attr_1 = 1.0
-        current = 1.0 * u.units.A
-
-    service_instance = ServiceClass()
-    state_manager = StateManager(service_instance)
-    DataServiceObserver(state_manager)
-    service_instance.attr_1 = 2
-
-    assert "'attr_1' changed to '2'" in caplog.text
-    assert (
-        "Type of 'attr_1' changed from 'float' to 'int'. This may have unwanted "
-        "side effects! Consider setting it to 'float' directly." in caplog.text
-    )
-
-    service_instance.current = 2
-    assert "'current' changed to '2'" in caplog.text
-    assert (
-        "Type of 'current' changed from 'Quantity' to 'int'. This may have unwanted "
-        "side effects! Consider setting it to 'Quantity' directly." in caplog.text
-    )
+import pydase
+import pydase.units as u
+from pydase import DataService
+from pydase.utils.decorators import FunctionDefinitionError, frontend
 
 
 def test_basic_inheritance_warning(caplog: LogCaptureFixture) -> None:


### PR DESCRIPTION
Adding keys to dictionaries trigger this warning, so I would consider this warning to not be useful any more.